### PR TITLE
make __doc__ of class members writable

### DIFF
--- a/src/CPPDataMember.cxx
+++ b/src/CPPDataMember.cxx
@@ -177,7 +177,7 @@ static CPPDataMember* pp_new(PyTypeObject* pytype, PyObject*, PyObject*)
     pyprop->fConverter      = nullptr;
     pyprop->fEnclosingScope = 0;
     pyprop->fDescription    = nullptr;
-    pyprop->fDoc            = PyUnicode_FromString("");
+    pyprop->fDoc            = nullptr;
 
     return pyprop;
 }
@@ -195,7 +195,7 @@ static void pp_dealloc(CPPDataMember* pyprop)
 }
 
 static PyMemberDef pp_members[] = {
-        {(char*)"__doc__", T_OBJECT_EX, offsetof(CPPDataMember, fDoc), 0,
+        {(char*)"__doc__", T_OBJECT, offsetof(CPPDataMember, fDoc), 0,
                 (char*)"writable documentation"},
         {NULL}  /* Sentinel */
 };

--- a/src/CPPDataMember.cxx
+++ b/src/CPPDataMember.cxx
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <vector>
 #include <limits.h>
+#include <structmember.h>
 
 
 namespace CPyCppyy {
@@ -176,6 +177,7 @@ static CPPDataMember* pp_new(PyTypeObject* pytype, PyObject*, PyObject*)
     pyprop->fConverter      = nullptr;
     pyprop->fEnclosingScope = 0;
     pyprop->fDescription    = nullptr;
+    pyprop->fDoc            = PyUnicode_FromString("");
 
     return pyprop;
 }
@@ -187,10 +189,16 @@ static void pp_dealloc(CPPDataMember* pyprop)
     using namespace std;
     if (pyprop->fConverter && pyprop->fConverter->HasState()) delete pyprop->fConverter;
     Py_XDECREF(pyprop->fDescription);  // never exposed so no GC necessary
+    Py_XDECREF(pyprop->fDoc);
 
     Py_TYPE(pyprop)->tp_free((PyObject*)pyprop);
 }
 
+static PyMemberDef pp_members[] = {
+        {(char*)"__doc__", T_OBJECT_EX, offsetof(CPPDataMember, fDoc), 0,
+                (char*)"writable documentation"},
+        {NULL}  /* Sentinel */
+};
 
 //= CPyCppyy data member type ================================================
 PyTypeObject CPPDataMember_Type = {
@@ -222,7 +230,7 @@ PyTypeObject CPPDataMember_Type = {
     0,                             // tp_iter
     0,                             // tp_iternext
     0,                             // tp_methods
-    0,                             // tp_members
+    pp_members,                    // tp_members
     0,                             // tp_getset
     0,                             // tp_base
     0,                             // tp_dict

--- a/src/CPPDataMember.h
+++ b/src/CPPDataMember.h
@@ -27,6 +27,7 @@ public:                 // public, as the python C-API works with C structs
     Converter*         fConverter;
     Cppyy::TCppScope_t fEnclosingScope;
     PyObject*          fDescription;
+    PyObject*          fDoc;
 
 private:                // private, as the python C-API will handle creation
     CPPDataMember() = delete;

--- a/src/CPPOverload.h
+++ b/src/CPPOverload.h
@@ -40,13 +40,15 @@ public:
     typedef std::vector<PyCallable*> Methods_t;
 
     struct MethodInfo_t {
-        MethodInfo_t() : fFlags(CallContext::kNone) { fRefCount = new int(1); }
+        MethodInfo_t() : fFlags(CallContext::kNone), fDoc(nullptr)
+            { fRefCount = new int(1); }
         ~MethodInfo_t();
 
         std::string                 fName;
         CPPOverload::DispatchMap_t  fDispatchMap;
         CPPOverload::Methods_t      fMethods;
         uint32_t                    fFlags;
+        PyObject*                   fDoc;
 
         int* fRefCount;
 

--- a/src/CPPOverload.h
+++ b/src/CPPOverload.h
@@ -47,8 +47,8 @@ public:
         std::string                 fName;
         CPPOverload::DispatchMap_t  fDispatchMap;
         CPPOverload::Methods_t      fMethods;
-        uint32_t                    fFlags;
         PyObject*                   fDoc;
+        uint32_t                    fFlags;
 
         int* fRefCount;
 

--- a/src/CPPScope.cxx
+++ b/src/CPPScope.cxx
@@ -402,6 +402,7 @@ static PyObject* meta_getattro(PyObject* pyclass, PyObject* pyname)
                         typedefpointertoclassobject* tpc =
                             PyObject_GC_New(typedefpointertoclassobject, &TypedefPointerToClass_Type);
                         tpc->fType = tcl;
+                        tpc->fDict = PyDict_New();
                         attr = (PyObject*)tpc;
                     }
                 }

--- a/src/CustomPyTypes.cxx
+++ b/src/CustomPyTypes.cxx
@@ -77,12 +77,48 @@ PyTypeObject TypedefPointerToClass_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     (char*)"cppyy.TypedefPointerToClass",// tp_name
     sizeof(typedefpointertoclassobject), // tp_basicsize
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    (ternaryfunc)tpc_call,        // tp_call
-    0, 0, 0, 0,
-    Py_TPFLAGS_DEFAULT |
-        Py_TPFLAGS_HAVE_GC,       // tp_flags
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    0,                              // tp_itemsize
+    0,                              // tp_dealloc
+    0,                              // tp_vectorcall_offset
+    0,                              // tp_getattr
+    0,                              // tp_setattr
+    0,                              // tp_as_async
+    0,                              // tp_repr
+    0,                              // tp_as_number
+    0,                              // tp_as_sequence
+    0,                              // tp_as_mapping
+    0,                              // tp_hash
+    (ternaryfunc)tpc_call,          // tp_call
+    0,                              // tp_str
+    PyObject_GenericGetAttr,        // tp_getattro
+    PyObject_GenericSetAttr,        // tp_setattro
+    0,                              // tp_as_buffer
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, // tp_flags
+    0,                              // tp_doc
+    0,                              // tp_traverse
+    0,                              // tp_clear
+    0,                              // tp_richcompare
+    0,                              // tp_weaklistoffset
+    0,                              // tp_iter
+    0,                              // tp_iternext
+    0,                              // tp_methods
+    0,                              // tp_members
+    0,                              // tp_getset
+    0,                              // tp_base
+    0,                              // tp_dict
+    0,                              // tp_descr_get
+    0,                              // tp_descr_set
+    offsetof(typedefpointertoclassobject, fDict), // tp_dictoffset
+    0,                              // tp_init
+    0,                              // tp_alloc
+    0,                              // tp_new
+    0,                              // tp_free
+    0,                              // tp_is_gc
+    0,                              // tp_bases
+    0,                              // tp_mro
+    0,                              // tp_cache
+    0,                              // tp_subclasses
+    0                               // tp_weaklist
 #if PY_VERSION_HEX >= 0x02030000
     , 0                           // tp_del
 #endif

--- a/src/CustomPyTypes.h
+++ b/src/CustomPyTypes.h
@@ -43,6 +43,11 @@ inline bool RefInt_CheckExact(T* object)
 struct typedefpointertoclassobject {
     PyObject_HEAD
     Cppyy::TCppType_t        fType;
+    PyObject*                fDict;
+
+    ~typedefpointertoclassobject() {
+        Py_DECREF(fDict);
+    }
 };
 
 extern PyTypeObject TypedefPointerToClass_Type;

--- a/src/TemplateProxy.cxx
+++ b/src/TemplateProxy.cxx
@@ -408,13 +408,6 @@ static int tpp_doc_set(TemplateProxy* pytmpl, PyObject *val, void *)
 }
 
 //----------------------------------------------------------------------------
-static PyObject* tpp_repr(TemplateProxy* pytmpl)
-{
-// Simply return the doc string as that's the most useful info (this will appear
-// on clsses on calling help()).
-     return tpp_doc(pytmpl, nullptr);
-}
-
 
 //= CPyCppyy template proxy callable behavior ================================
 
@@ -782,7 +775,7 @@ PyTypeObject TemplateProxy_Type = {
     0,                                 // tp_getattr
     0,                                 // tp_setattr
     0,                                 // tp_as_async / tp_compare
-    (reprfunc)tpp_repr,                // tp_repr
+    0,                                 // tp_repr
     0,                                 // tp_as_number
     0,                                 // tp_as_sequence
     &tpp_as_mapping,                   // tp_as_mapping

--- a/src/TemplateProxy.h
+++ b/src/TemplateProxy.h
@@ -39,6 +39,7 @@ public:
     CPPOverload* fLowPriority;    // low priority overloads such as void*/void**
 
     TP_DispatchMap_t fDispatchMap;
+    PyObject* fDoc;
 };
 
 typedef std::shared_ptr<TemplateInfo> TP_TInfo_t;

--- a/src/TypeManip.cxx
+++ b/src/TypeManip.cxx
@@ -162,7 +162,7 @@ std::string CPyCppyy::TypeManip::compound(const std::string& name)
     const std::string& cpd = cleanName.substr(idx, std::string::npos);
 
 // for easy identification of fixed size arrays
-    if (cpd.back() == ']') {
+    if (!cpd.empty() && cpd.back() == ']') {
         std::ostringstream scpd;
         if (cpd.front() != '[') scpd << cpd.substr(0, cpd.find('['));
         for (auto c : cpd)


### PR DESCRIPTION
See my initial issue [here](https://bitbucket.org/wlav/cppyy/issues/339/make-c-documentation-available-to-python). Regarding your [comment](https://bitbucket.org/wlav/cppyy/issues/369/template-instantiation-not-happening-in#comment-61161603):
> I was kindof hoping to find a solution that doesn’t require adding another pointer CPPOverload::MethodInfo_t. Not sure whether that’s possible, though, but the whole structure could be reduced: there need not be a separate dispatch map as a loop over methods would be just as fast and fName is hardly used (only in error reporting and __str__), so could be on-demand instead.

...I took the easy path and did exactly that to `CPPDataMember` (where I could add the member field directly to the class), `TemplateProxy`, and `CPPOverload` (where I added the member field to the persistent `CPPOverload::MethodInfo_t` / `TemplateInfo` object and adapted the `__doc__` getter of / added a setter to the enclosing object). By default, the getters return the auto-generated docstring, unless the user overwrote it with a custom value. I guess you need to store the string value somewhere, unless you want to give the objects their whole, customizable `__dict__` with `tp_dictoffset`, but you'd also need to store that somewhere. I'm unsure whether something similar needs to be done to `CustomInstanceMethod`, `TypedefPointerToClass`, `CPPInstance`, and `CPPExcInstance`, as I didn't have a class at hand that wraps those. At least the current changes in this PR seem to cover my use-case from the Bitbucket issue.

Regarding the hook for `CPPScope.__getattr__` discussed [here](https://bitbucket.org/wlav/cppyy/issues/339/make-c-documentation-available-to-python#comment-60495916), I guess I would also add a PyCallable member to `CPPScope` that gets called [here](https://github.com/wlav/CPyCppyy/blob/master/src/CPPScope.cxx#L518) in the native implementation of `meta_getattro` to provide a replacement value if no other alternative could be found.