### PR TITLE
CPPMethod::GetArgMatchScore now runs CompareMethodArgType on ref, const ref and ptr of the requested type

### DIFF
--- a/src/CPPMethod.cxx
+++ b/src/CPPMethod.cxx
@@ -676,13 +676,11 @@ int CPyCppyy::CPPMethod::GetArgMatchScore(PyObject* args_tuple)
 
         // Method is not compatible if even one argument does not match
         if (arg_score >= 10) {
-          score = INT_MAX;
-                    break;
+            score = INT_MAX;
+            break;
         }
-
         score += arg_score;
     }
-
     return score;
 }
 

--- a/src/CPPMethod.cxx
+++ b/src/CPPMethod.cxx
@@ -676,15 +676,8 @@ int CPyCppyy::CPPMethod::GetArgMatchScore(PyObject* args_tuple)
 
         // Method is not compatible if even one argument does not match
         if (arg_score >= 10) {
-           std::string ref_type = req_type + "&";
-           std::string const_ref_type = "const " + req_type + "&";
-           std::string ptr_type = req_type + "*";
-           arg_score = std::min(Cppyy::CompareMethodArgType(fMethod, i, ptr_type), 
-           std::min(Cppyy::CompareMethodArgType(fMethod, i, ref_type), Cppyy::CompareMethodArgType(fMethod, i, const_ref_type)));
-                if (arg_score >= 10) {
-                    score = INT_MAX;
+          score = INT_MAX;
                     break;
-                }
         }
 
         score += arg_score;

--- a/src/CPPMethod.cxx
+++ b/src/CPPMethod.cxx
@@ -676,8 +676,15 @@ int CPyCppyy::CPPMethod::GetArgMatchScore(PyObject* args_tuple)
 
         // Method is not compatible if even one argument does not match
         if (arg_score >= 10) {
-            score = INT_MAX;
-            break;
+           std::string ref_type = req_type + "&";
+           std::string const_ref_type = "const " + req_type + "&";
+           std::string ptr_type = req_type + "*";
+           arg_score = std::min(Cppyy::CompareMethodArgType(fMethod, i, ptr_type), 
+           std::min(Cppyy::CompareMethodArgType(fMethod, i, ref_type), Cppyy::CompareMethodArgType(fMethod, i, const_ref_type)));
+                if (arg_score >= 10) {
+                    score = INT_MAX;
+                    break;
+                }
         }
 
         score += arg_score;

--- a/src/Cppyy.h
+++ b/src/Cppyy.h
@@ -210,6 +210,8 @@ namespace Cppyy {
     CPPYY_IMPORT
     TCppIndex_t CompareMethodArgType(TCppMethod_t, TCppIndex_t iarg, const std::string &req_type);
     CPPYY_IMPORT
+    TCppIndex_t GetArgScore(void *argqtp, void *reqqtp);
+    CPPYY_IMPORT
     std::string GetMethodArgDefault(TCppMethod_t, TCppIndex_t iarg);
     CPPYY_IMPORT
     std::string GetMethodSignature(TCppMethod_t, bool show_formalargs, TCppIndex_t maxargs = (TCppIndex_t)-1);

--- a/src/Cppyy.h
+++ b/src/Cppyy.h
@@ -210,7 +210,7 @@ namespace Cppyy {
     CPPYY_IMPORT
     TCppIndex_t CompareMethodArgType(TCppMethod_t, TCppIndex_t iarg, const std::string &req_type);
     CPPYY_IMPORT
-    TCppIndex_t GetArgScore(void *argqtp, void *reqqtp);
+    TCppIndex_t ArgSimilarityScore(void *argqtp, void *reqqtp);
     CPPYY_IMPORT
     std::string GetMethodArgDefault(TCppMethod_t, TCppIndex_t iarg);
     CPPYY_IMPORT


### PR DESCRIPTION
Part of getting the right ```__overload__``` match on the numba side when the args are passed by ref/ptr to an overload
@sudo-panda @wlav 