### PR TITLE
Improve integer type checking in `Utility::GetBuffer()`

### DIFF
--- a/src/Utility.cxx
+++ b/src/Utility.cxx
@@ -825,10 +825,11 @@ Py_ssize_t CPyCppyy::Utility::GetBuffer(PyObject* pyobject, char tc, int size, v
         memset(&bufinfo, 0, sizeof(Py_buffer));
         if (PyObject_GetBuffer(pyobject, &bufinfo, PyBUF_FORMAT) == 0) {
             if (tc == '*' || strchr(bufinfo.format, tc)
-#ifdef _WIN32
-            // ctypes is inconsistent in format on Windows; either way these types are the same size
-                || (tc == 'I' && strchr(bufinfo.format, 'L')) || (tc == 'i' && strchr(bufinfo.format, 'l'))
-#endif
+            // if `long int` and `int` are the same size (on 32-bit Windows and
+            // some Linux), `ctypes` isn't too picky about the type format,
+            // which doesn't matter because of the same size anyway
+                || (sizeof(long int) == sizeof(int) && ((tc == 'I' && strchr(bufinfo.format, 'L')) ||
+                                                        (tc == 'i' && strchr(bufinfo.format, 'l'))))
             // complex float is 'Zf' in bufinfo.format, but 'z' in single char
                 || (tc == 'z' && strstr(bufinfo.format, "Zf"))
             // allow 'signed char' ('b') from array to pass through '?' (bool as from struct)


### PR DESCRIPTION
The inconsistent types were also observed on 32-bit Linux.

In ROOT, this was hotfixed by adding a check for 32-bit Linux in the
preprecessor check, but this required including `RConfig.h`. I don't
think this is desirable.

A better and more direct check for the underlying problem case is to
check if `long int` and `int` have the same size.

This is part of the effort to reduce the differences between PyROOT and
upstream CPyCppyy.

Related commits:
* https://github.com/wlav/CPyCppyy/commit/8a72866
* root-project@02251b5