### PR TITLE
Carry a copy of the string also in the `std::string_view` converter and consider statefulness in `InitializerListConverter`

### DIFF
--- a/src/Converters.h
+++ b/src/Converters.h
@@ -17,6 +17,13 @@ class CPYCPPYY_CLASS_EXPORT Converter {
 public:
     virtual ~Converter();
 
+    Converter() = default;
+
+    Converter(Converter const& other) = delete;
+    Converter(Converter && other) = delete;
+    Converter& operator=(Converter const& other) = delete;
+    Converter& operator=(Converter && other) = delete;
+
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) = 0;
     virtual PyObject* FromMemory(void* address);

--- a/src/DeclareConverters.h
+++ b/src/DeclareConverters.h
@@ -351,21 +351,26 @@ CPPYY_DECLARE_BASIC_CONVERTER(PyObject);
 class name##Converter : public InstanceConverter {                           \
 public:                                                                      \
     name##Converter(bool keepControl = true);                                \
-public:                                                                      \
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);      \
     virtual PyObject* FromMemory(void* address);                             \
     virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);            \
     virtual bool HasState() { return true; }                                 \
 protected:                                                                   \
-    strtype fBuffer;                                                         \
+    strtype fStringBuffer;                                                   \
 }
 
 CPPYY_DECLARE_STRING_CONVERTER(STLString, std::string);
 #if __cplusplus > 201402L
-CPPYY_DECLARE_STRING_CONVERTER(STLStringViewBase, std::string_view);
+// The buffer type needs to be std::string also in the string_view case,
+// otherwise the pointed-to string might not live long enough. See also:
+// https://github.com/wlav/CPyCppyy/issues/13
+CPPYY_DECLARE_STRING_CONVERTER(STLStringViewBase, std::string);
 class STLStringViewConverter : public STLStringViewBaseConverter {
 public:
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
+    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);
+private:
+    std::string_view fStringView;
 };
 #endif
 CPPYY_DECLARE_STRING_CONVERTER(STLWString, std::wstring);

--- a/src/DeclareConverters.h
+++ b/src/DeclareConverters.h
@@ -449,9 +449,7 @@ protected:
 // initializer lists
 class InitializerListConverter : public InstanceConverter {
 public:
-    InitializerListConverter(Cppyy::TCppType_t klass,
-            Converter* cnv, Cppyy::TCppType_t valuetype, size_t sz) : InstanceConverter(klass),
-        fBuffer(nullptr), fConverter(cnv), fValueType(valuetype), fValueSize(sz) {}
+    InitializerListConverter(Cppyy::TCppType_t klass, std::string const& value_type);
     InitializerListConverter(const InitializerListConverter&) = delete;
     InitializerListConverter& operator=(const InitializerListConverter&) = delete;
     virtual ~InitializerListConverter();
@@ -464,8 +462,9 @@ protected:
     void Clear();
 
 protected:
-    void*             fBuffer;
-    Converter*        fConverter;
+    void*             fBuffer = nullptr;
+    std::vector<Converter*> fConverters;
+    std::string       fValueTypeName;
     Cppyy::TCppType_t fValueType;
     size_t            fValueSize;
 };


### PR DESCRIPTION
There are two possible fixes to the problem with string lifetimes and `std::string_view` arguments:

  * setting a lifeline

  * copying the string

Copying the string is supposedly faster on average, at least in the ROOT usecase the strings that are passed around are not very long (RDataFrame filter and variable definitions).

Also, the `InitializerListConverter` is changed such that it creates separate converters for each element if the converters have state.

This PR fixes the following reproducer:

```Python
If they have state, a separate converter needs to be created for each
element in the initializer list.

Fixes the following reproducer:

```python
import cppyy

cppyy.cppdef("""
void foo(std::string_view s1, std::string_view s2)
{
   std::cout << s1 << std::endl;
   std::cout << s2 << std::endl;
   std::cout << std::endl;
}

void bar(std::initializer_list<std::string_view> sl)
{
   for (auto const& s : sl) {
      std::cout << s << std::endl;
   }
   std::cout << std::endl;
}
""")

cppyy.gbl.foo("hello", "world")
cppyy.gbl.bar(["hello", "world"])
```

Closes #13.