### PR TITLE
Improve output of `CPPMethod::GetPrototype`

### DIFF
--- a/src/CPPMethod.cxx
+++ b/src/CPPMethod.cxx
@@ -369,13 +369,41 @@ CPyCppyy::CPPMethod::~CPPMethod()
 
 
 //- public members -----------------------------------------------------------
+/**
+ * @brief Construct a Python string from the method's prototype
+ * 
+ * @param fa Show formal arguments of the method
+ * @return PyObject* A Python string with the full method prototype, namespaces included.
+ * 
+ * For example, given:
+ * 
+ * int foo(int x);
+ * 
+ * namespace a {
+ * namespace b {
+ * namespace c {
+ * int foo(int x);
+ * }}}
+ * 
+ * This function returns:
+ * 
+ * 'int foo(int x)'
+ * 'int a::b::c::foo(int x)'
+ */
 PyObject* CPyCppyy::CPPMethod::GetPrototype(bool fa)
 {
-// construct python string from the method's prototype
-    return CPyCppyy_PyText_FromFormat("%s%s %s::%s%s",
+    // Gather the fully qualified final scope of the method. This includes
+    // all namespaces up to the one where the method is declared, for example:
+    // namespace a { namespace b { void foo(); }}
+    // gives
+    // a::b
+    std::string finalscope = Cppyy::GetScopedFinalName(fScope);
+    return CPyCppyy_PyText_FromFormat("%s%s %s%s%s%s",
         (Cppyy::IsStaticMethod(fMethod) ? "static " : ""),
         Cppyy::GetMethodResultType(fMethod).c_str(),
-        Cppyy::GetScopedFinalName(fScope).c_str(), Cppyy::GetMethodName(fMethod).c_str(),
+        finalscope.c_str(),
+        (finalscope.empty() ? "" : "::"), // Add final set of '::' if the method is scoped in namespace(s)
+        Cppyy::GetMethodName(fMethod).c_str(),
         GetSignatureString(fa).c_str());
 }
 


### PR DESCRIPTION
Given the following function declared to cppyy and accessed via a Python proxy:

```c++
int foo(int x);
```

Currently accessing its `func_doc`, which in turn calls `CPPMethod::GetPrototype`, gives:

'int ::foo(int x)'

The extra set of '::' can be avoided by checking that the function is not declared inside a namespace.

See also the corresponding ROOT PR:
https://github.com/root-project/root/pull/11413

Cudos goes to @vepadulano, the original author of this commit.