### PR TITLE
Improve priority assignment of classes in same inheritance tree

### DIFF
--- a/src/CPPMethod.cxx
+++ b/src/CPPMethod.cxx
@@ -484,7 +484,7 @@ int CPyCppyy::CPPMethod::GetPriority()
             const std::string& clean_name = TypeManip::clean_type(aname, false);
             Cppyy::TCppScope_t scope = Cppyy::GetScope(clean_name);
             if (scope)
-                priority += (int)Cppyy::GetNumBases(scope);
+                priority += static_cast<int>(Cppyy::GetNumBasesLongestBranch(scope));
 
             if (Cppyy::IsEnum(clean_name))
                 priority -= 100;

--- a/src/Cppyy.h
+++ b/src/Cppyy.h
@@ -164,6 +164,8 @@ namespace Cppyy {
     CPPYY_IMPORT
     TCppIndex_t GetNumBases(TCppType_t type);
     CPPYY_IMPORT
+    TCppIndex_t GetNumBasesLongestBranch(TCppType_t type);
+    CPPYY_IMPORT
     std::string GetBaseName(TCppType_t type, TCppIndex_t ibase);
     CPPYY_IMPORT
     bool        IsSubtype(TCppType_t derived, TCppType_t base);


### PR DESCRIPTION
 - **Port of https://github.com/root-project/root/pull/9092**
 - **Corresponding cppyy-backend PR: https://github.com/wlav/cppyy-backend/pull/20**

---------------------

The current implementation of the CPPMethod::GetPriority function considers only direct bases of the class type given as input parameter to a certain function. This can lead to situations which are easily distinguishable but that lead to the same overload being called when passing instances of different classes of the same inheritance tree.

For example,
```python
import ROOT

ROOT.gInterpreter.Declare(
'''
class A {};
class B: public A {};
class C: public B {};

void myfunc(const B &b){
    std::cout << "B" << std::endl;
}

void myfunc(const C &c){
    std::cout << "C" << std::endl;
}

''')

ROOT.myfunc(ROOT.B())
ROOT.myfunc(ROOT.C())
```

Prints `B` for both function calls. This commit introduces a new function in cppyy that retrieves the number of bases in the longest branch of the inheritance tree for a certain class. This helps better distinguish cases like the one above, that are now solved.

The new logic still does not solve another issue, namely the fact that in certain situations which would throw errors in C++ due to their ambiguity, cppyy resorts to calling the function overload with the highest priority. A couple of tests have been added in roottest to show both behaviours.