### PR TITLE
Support conversion from `str` to `char[]`

### DIFF
--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -1572,6 +1572,42 @@ bool CPyCppyy::VoidArrayConverter::ToMemory(PyObject* value, void* address, PyOb
     return true;
 }
 
+namespace {
+
+// Copy a buffer to memory address with an array converter.
+template<class type>
+bool ToArrayFromBuffer(PyObject* owner, void* address, PyObject* ctxt,
+                       const void * buf, Py_ssize_t buflen,
+                       CPyCppyy::dims_t& shape, bool isFixed)
+{
+    if (buflen == 0)
+        return false;
+
+    Py_ssize_t oldsz = 1;
+    for (Py_ssize_t idim = 0; idim < shape.ndim(); ++idim) {
+        if (shape[idim] == CPyCppyy::UNKNOWN_SIZE) {
+            oldsz = -1;
+            break;
+        }
+        oldsz *= shape[idim];
+    }
+    if (shape.ndim() != CPyCppyy::UNKNOWN_SIZE && 0 < oldsz && oldsz < buflen) {
+        PyErr_SetString(PyExc_ValueError, "buffer too large for value");
+        return false;
+    }
+
+    if (isFixed)
+        memcpy(*(type**)address, buf, (0 < buflen ? buflen : 1)*sizeof(type));
+    else {
+        *(type**)address = (type*)buf;
+        shape.ndim(1);
+        shape[0] = buflen;
+        SetLifeLine(ctxt, owner, (intptr_t)address);
+    }
+    return true;
+}
+
+}
 
 //----------------------------------------------------------------------------
 #define CPPYY_IMPL_ARRAY_CONVERTER(name, ctype, type, code, suffix)          \
@@ -1652,31 +1688,7 @@ bool CPyCppyy::name##ArrayConverter::ToMemory(                               \
     if (fShape.ndim() <= 1 || fIsFixed) {                                    \
         void* buf = nullptr;                                                 \
         Py_ssize_t buflen = Utility::GetBuffer(value, code, sizeof(type), buf);\
-        if (buflen == 0)                                                     \
-            return false;                                                    \
-                                                                             \
-        Py_ssize_t oldsz = 1;                                                \
-        for (Py_ssize_t idim = 0; idim < fShape.ndim(); ++idim) {            \
-            if (fShape[idim] == UNKNOWN_SIZE) {                              \
-                oldsz = -1;                                                  \
-                break;                                                       \
-            }                                                                \
-            oldsz *= fShape[idim];                                           \
-        }                                                                    \
-        if (fShape.ndim() != UNKNOWN_SIZE && 0 < oldsz && oldsz < buflen) {  \
-            PyErr_SetString(PyExc_ValueError, "buffer too large for value"); \
-            return false;                                                    \
-        }                                                                    \
-                                                                             \
-        if (fIsFixed)                                                        \
-            memcpy(*(type**)address, buf, (0 < buflen ? buflen : 1)*sizeof(type));\
-        else {                                                               \
-            *(type**)address = (type*)buf;                                   \
-            fShape.ndim(1);                                                  \
-            fShape[0] = buflen;                                              \
-            SetLifeLine(ctxt, value, (intptr_t)address);                     \
-        }                                                                    \
-                                                                             \
+        return ToArrayFromBuffer<type>(value, address, ctxt, buf, buflen, fShape, fIsFixed);\
     } else { /* multi-dim, non-flat array; assume structure matches */       \
         void* buf = nullptr; /* TODO: GetBuffer() assumes flat? */           \
         Py_ssize_t buflen = Utility::GetBuffer(value, code, sizeof(void*), buf);\
@@ -1773,6 +1785,18 @@ PyObject* CPyCppyy::CStringArrayConverter::FromMemory(void* address)
     else if (fShape[0] == UNKNOWN_SIZE)
         return CreateLowLevelViewString((const char**)address, fShape);
     return CreateLowLevelViewString(*(const char***)address, fShape);
+}
+
+//----------------------------------------------------------------------------
+bool CPyCppyy::CStringArrayConverter::ToMemory(PyObject* value, void* address, PyObject* ctxt)
+{
+// As a special array converter, the CStringArrayConverter one can also copy strings in the array,
+// and not only buffers.
+    Py_ssize_t len;
+    if (const char* cstr = CPyCppyy_PyText_AsStringAndSize(value, &len)) {
+        return ToArrayFromBuffer<char>(value, address, ctxt, cstr, len, fShape, fIsFixed);
+    }
+    return SCharArrayConverter::ToMemory(value, address, ctxt);
 }
 
 //----------------------------------------------------------------------------

--- a/src/DeclareConverters.h
+++ b/src/DeclareConverters.h
@@ -229,6 +229,7 @@ public:
     using SCharArrayConverter::SCharArrayConverter;
     virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
     virtual PyObject* FromMemory(void* address);
+    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);
 
 private:
     std::vector<const char*> fBuffer;


### PR DESCRIPTION
This is for the ROOT usecase, where `char[]` is sometimes used as column types in TTrees to contain fixed-sized string labels.

This is tested by the ROOT synchronization PR, where the `staff.py` tutorial is now passing:
https://github.com/root-project/root/pull/14507