### PR TITLE
Correcly forward `control` flag to InstancePtrConverter

### DIFF
--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -3039,7 +3039,7 @@ static inline CPyCppyy::Converter* selectInstanceCnv(Cppyy::TCppScope_t klass,
     else if (cpd == "*&")
         result = new InstancePtrPtrConverter<true>(klass, control);
     else if (cpd == "*" && dims.ndim() == UNKNOWN_SIZE) {
-        if (isConst) result = new InstancePtrConverter<true>(klass);
+        if (isConst) result = new InstancePtrConverter<true>(klass, control);
         else result = new InstancePtrConverter<false>(klass, control);
     }
     else if (cpd == "&")


### PR DESCRIPTION
Closes https://github.com/wlav/cppyy/issues/221, if the change in memory policy was accidental.

This fixes the memory test in the synchronization PR:
https://github.com/root-project/root/pull/14507