### PR TITLE
Don't attempt to print detailed exception info if filename is empty

### DIFF
--- a/src/PyException.cxx
+++ b/src/PyException.cxx
@@ -93,16 +93,18 @@ CPyCppyy::PyException::PyException()
     if (fMsg.empty())
         fMsg = "python exception";
 
-// only keeping the filename, not the full path
-    if (!locFile.empty())
+    if (!locFile.empty()) {
+
+        // only keeping the filename, not the full path
         locFile = locFile.substr(locFile.find_last_of("/\\") + 1);
 
-    fMsg += " (at " + locFile + ":" + std::to_string(locLine);
+        fMsg += " (at " + locFile + ":" + std::to_string(locLine);
 
-    if (locName != "<module>")
-        fMsg += " in " + locName;
+        if (locName != "<module>")
+            fMsg += " in " + locName;
 
-    fMsg += ")";
+        fMsg += ")";
+    }
 
 #ifdef WITH_THREAD
     PyGILState_Release(state);


### PR DESCRIPTION
This can happen for example with jitted code, and would lead to this ugly printout otherwise:
```
python exception (at :0 )
```
Maybe a bit pedantic, but our unit tests in ROOT were testing for the exact wording, which is why I suggest to fix this.