### PR TITLE
Fix `missing-field-initializers` with Python 3.12

### DIFF
--- a/src/CPPDataMember.cxx
+++ b/src/CPPDataMember.cxx
@@ -307,6 +307,9 @@ PyTypeObject CPPDataMember_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/CPPExcInstance.cxx
+++ b/src/CPPExcInstance.cxx
@@ -289,6 +289,9 @@ PyTypeObject CPPExcInstance_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                            // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                            // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/CPPInstance.cxx
+++ b/src/CPPInstance.cxx
@@ -1086,6 +1086,9 @@ PyTypeObject CPPInstance_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/CPPOverload.cxx
+++ b/src/CPPOverload.cxx
@@ -1052,6 +1052,9 @@ PyTypeObject CPPOverload_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                                // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                                // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/CPPScope.cxx
+++ b/src/CPPScope.cxx
@@ -707,6 +707,9 @@ PyTypeObject CPPScope_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/CPyCppyyModule.cxx
+++ b/src/CPyCppyyModule.cxx
@@ -161,6 +161,9 @@ static PyTypeObject PyNullPtr_t_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                  // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                  // tp_watched
+#endif
 };
 
 
@@ -196,7 +199,10 @@ static PyTypeObject PyDefault_t_Type = {
     , 0                  // tp_finalize
 #endif
 #if PY_VERSION_HEX >= 0x03080000
-    , 0                           // tp_vectorcall
+    , 0                 // tp_vectorcall
+#endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                 // tp_watched
 #endif
 };
 

--- a/src/CustomPyTypes.cxx
+++ b/src/CustomPyTypes.cxx
@@ -167,6 +167,9 @@ PyTypeObject TypedefPointerToClass_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
+#endif
 };
 
 //= instancemethod object with a more efficient call function ================
@@ -335,6 +338,9 @@ PyTypeObject CustomInstanceMethod_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
+#endif
 };
 
 
@@ -388,6 +394,9 @@ PyTypeObject IndexIter_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
+#endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
 #endif
 };
 
@@ -450,6 +459,9 @@ PyTypeObject VectorIter_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
+#endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
 #endif
 };
 

--- a/src/LowLevelViews.cxx
+++ b/src/LowLevelViews.cxx
@@ -956,6 +956,9 @@ PyTypeObject LowLevelView_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                            // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                            // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/TemplateProxy.cxx
+++ b/src/TemplateProxy.cxx
@@ -960,6 +960,9 @@ PyTypeObject TemplateProxy_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                                // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                                // tp_watched
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/TupleOfInstances.cxx
+++ b/src/TupleOfInstances.cxx
@@ -117,6 +117,9 @@ PyTypeObject InstanceArrayIter_Type = {
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
 #endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
+#endif
 };
 
 
@@ -247,6 +250,9 @@ PyTypeObject TupleOfInstances_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x03080000
     , 0                           // tp_vectorcall
+#endif
+#if PY_VERSION_HEX >= 0x030c0000
+    , 0                           // tp_watched
 #endif
 };
 


### PR DESCRIPTION
Adapting to a new field in Python 3.12:
https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_watched

Corresponding ROOT PR: https://github.com/root-project/root/pull/15072