### PR TITLE
Use correct `PYTHON_HEX_VERSION` for Python 3.12

### DIFF
--- a/src/CPPExcInstance.cxx
+++ b/src/CPPExcInstance.cxx
@@ -248,7 +248,7 @@ PyTypeObject CPPExcInstance_Type = {
         Py_TPFLAGS_BASE_EXC_SUBCLASS |
         Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_CHECKTYPES
-#if PY_VERSION_HEX >= 0x03120000
+#if PY_VERSION_HEX >= 0x030c0000
         | Py_TPFLAGS_MANAGED_DICT
 #endif
         ,                          // tp_flags

--- a/src/CPPInstance.cxx
+++ b/src/CPPInstance.cxx
@@ -1045,7 +1045,7 @@ PyTypeObject CPPInstance_Type = {
     Py_TPFLAGS_DEFAULT |
         Py_TPFLAGS_BASETYPE |
         Py_TPFLAGS_CHECKTYPES
-#if PY_VERSION_HEX >= 0x03120000
+#if PY_VERSION_HEX >= 0x030c0000
         | Py_TPFLAGS_MANAGED_DICT | Py_TPFLAGS_HAVE_GC | Py_TPFLAGS_MANAGED_WEAKREF
 #endif
         ,                          // tp_flags

--- a/src/CPPScope.cxx
+++ b/src/CPPScope.cxx
@@ -666,7 +666,7 @@ PyTypeObject CPPScope_Type = {
 #if PY_VERSION_HEX >= 0x03040000
         | Py_TPFLAGS_TYPE_SUBCLASS
 #endif
-#if PY_VERSION_HEX >= 0x03120000
+#if PY_VERSION_HEX >= 0x030c0000
         | Py_TPFLAGS_MANAGED_DICT | Py_TPFLAGS_HAVE_GC
 #endif
         ,                          // tp_flags

--- a/src/TemplateProxy.cxx
+++ b/src/TemplateProxy.cxx
@@ -919,7 +919,7 @@ PyTypeObject TemplateProxy_Type = {
 #if PY_VERSION_HEX >= 0x03080000
         | Py_TPFLAGS_HAVE_VECTORCALL | Py_TPFLAGS_METHOD_DESCRIPTOR
 #endif
-#if PY_VERSION_HEX >= 0x03120000
+#if PY_VERSION_HEX >= 0x030c0000
         | Py_TPFLAGS_MANAGED_WEAKREF
 #endif
         ,                              // tp_flags


### PR DESCRIPTION
`0x03120000` was probably meant to indicate Python 3.12, which in HEX is actually `0x030c0000`.