### PR TITLE
Destroy STL string objects in STLWStringExecutor

### DIFF
--- a/src/Executors.cxx
+++ b/src/Executors.cxx
@@ -590,7 +590,7 @@ PyObject* CPyCppyy::STLWStringExecutor::Execute(
     }
 
     PyObject* pyresult = PyUnicode_FromWideChar(result->c_str(), result->size());
-    ::operator delete(result); // calls Cppyy::CallO which calls ::operator new
+    delete result; // Cppyy::CallO allocates and constructs a string, so it must be properly destroyed
 
     return pyresult;
 }


### PR DESCRIPTION
::operator delete only frees the memory that was previously allocated in Cppyy::CallO, but does not call the destructor of the std::string. Make sure that is done using keyword delete.

This is part of a fix in ROOT that also applies to CPyCppyy:
https://github.com/root-project/root/pull/15777