### PR TITLE
Extend API to define executor and converter aliases

### DIFF
--- a/include/CPyCppyy/API.h
+++ b/include/CPyCppyy/API.h
@@ -132,6 +132,9 @@ CPYCPPYY_EXTERN void DestroyConverter(Converter* p);
 typedef Converter* (*ConverterFactory_t)(cdims_t);
 CPYCPPYY_EXTERN bool RegisterConverter(const std::string& name, ConverterFactory_t);
 
+// register a custom converter that is a reference to an existing converter
+CPYCPPYY_EXTERN bool RegisterConverterAlias(const std::string& name, const std::string& target);
+
 // remove a custom converter
 CPYCPPYY_EXTERN bool UnregisterConverter(const std::string& name);
 
@@ -158,6 +161,9 @@ CPYCPPYY_EXTERN void DestroyConverter(Converter* p);
 // register a custom executor
 typedef Executor* (*ExecutorFactory_t)(cdims_t);
 CPYCPPYY_EXTERN bool RegisterExecutor(const std::string& name, ExecutorFactory_t);
+
+// register a custom executor that is a reference to an existing converter
+CPYCPPYY_EXTERN bool RegisterExecutorAlias(const std::string& name, const std::string& target);
 
 // remove a custom executor
 CPYCPPYY_EXTERN bool UnregisterExecutor(const std::string& name);

--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -3286,6 +3286,23 @@ bool CPyCppyy::RegisterConverter(const std::string& name, cf_t fac)
 
 //----------------------------------------------------------------------------
 CPYCPPYY_EXPORT
+bool CPyCppyy::RegisterConverterAlias(const std::string& name, const std::string& target)
+{
+// register a custom converter that is a reference to an existing converter
+    auto f = gConvFactories.find(name);
+    if (f != gConvFactories.end())
+        return false;
+
+    auto t = gConvFactories.find(target);
+    if (t == gConvFactories.end())
+        return false;
+
+    gConvFactories[name] = t->second;
+    return true;
+}
+
+//----------------------------------------------------------------------------
+CPYCPPYY_EXPORT
 bool CPyCppyy::UnregisterConverter(const std::string& name)
 {
 // remove a custom converter

--- a/src/Converters.h
+++ b/src/Converters.h
@@ -36,6 +36,7 @@ CPYCPPYY_EXPORT Converter* CreateConverter(const std::string& fullType, cdims_t 
 CPYCPPYY_EXPORT void DestroyConverter(Converter* p);
 typedef Converter* (*cf_t)(cdims_t d);
 CPYCPPYY_EXPORT bool RegisterConverter(const std::string& name, cf_t fac);
+CPYCPPYY_EXPORT bool RegisterConverterAlias(const std::string& name, const std::string& target);
 CPYCPPYY_EXPORT bool UnregisterConverter(const std::string& name);
 
 

--- a/src/Executors.cxx
+++ b/src/Executors.cxx
@@ -924,6 +924,23 @@ bool CPyCppyy::RegisterExecutor(const std::string& name, ef_t fac)
 
 //----------------------------------------------------------------------------
 CPYCPPYY_EXPORT
+bool CPyCppyy::RegisterExecutorAlias(const std::string& name, const std::string& target)
+{
+// register a custom executor that is a reference to an existing converter
+    auto f = gExecFactories.find(name);
+    if (f != gExecFactories.end())
+        return false;
+
+    auto t = gExecFactories.find(target);
+    if (t == gExecFactories.end())
+        return false;
+
+    gExecFactories[name] = t->second;
+    return true;
+}
+
+//----------------------------------------------------------------------------
+CPYCPPYY_EXPORT
 bool CPyCppyy::UnregisterExecutor(const std::string& name)
 {
 // remove a custom executor

--- a/src/Executors.h
+++ b/src/Executors.h
@@ -36,6 +36,7 @@ CPYCPPYY_EXPORT Executor* CreateExecutor(const std::string& fullType, cdims_t = 
 CPYCPPYY_EXPORT void DestroyExecutor(Executor* p);
 typedef Executor* (*ef_t) (cdims_t);
 CPYCPPYY_EXPORT bool RegisterExecutor(const std::string& name, ef_t fac);
+CPYCPPYY_EXPORT bool RegisterExecutorAlias(const std::string& name, const std::string& target);
 CPYCPPYY_EXPORT bool UnregisterExecutor(const std::string& name);
 
 // helper for the actual call


### PR DESCRIPTION
It would be nice to be able to define custom executors and converters that are just referencing existing ones.

That would for example help to support the legacy ROOT types without having to patch CPyCppyy:

  * https://github.com/root-project/root/pull/15788