### PR TITLE
Fix failing python enums with LLVM18

### DIFF
--- a/src/CPPDataMember.cxx
+++ b/src/CPPDataMember.cxx
@@ -187,7 +187,6 @@ static CPPDataMember* dm_new(PyTypeObject* pytype, PyObject*, PyObject*)
 // Create and initialize a new property descriptor.
     CPPDataMember* dm = (CPPDataMember*)pytype->tp_alloc(pytype, 0);
 
-    dm->fOffset         = 0;
     dm->fFlags          = 0;
     dm->fConverter      = nullptr;
     dm->fEnclosingScope = 0;
@@ -374,17 +373,6 @@ void CPyCppyy::CPPDataMember::Set(Cppyy::TCppScope_t scope, Cppyy::TCppIndex_t i
 
     if (!(fFlags & kIsEnumPrep))
         fDescription = CPyCppyy_PyText_FromString(name.c_str());
-}
-
-//-----------------------------------------------------------------------------
-void CPyCppyy::CPPDataMember::Set(Cppyy::TCppScope_t scope, const std::string& name, void* address)
-{
-    fEnclosingScope = scope;
-    fDescription    = CPyCppyy_PyText_FromString(name.c_str());
-    fOffset         = (intptr_t)address;
-    fFlags          = kIsStaticData | kIsConstData;
-    fConverter      = CreateConverter("internal_enum_type_t");
-    fFullType       = "unsigned int";
 }
 
 

--- a/src/CPPDataMember.cxx
+++ b/src/CPPDataMember.cxx
@@ -36,7 +36,7 @@ static PyObject* dm_get(CPPDataMember* dm, CPPInstance* pyobj, PyObject* /* kls 
     if (pyobj && dm->fFlags & kIsCachable) {
         CPyCppyy::CI_DatamemberCache_t& cache = pyobj->GetDatamemberCache();
         for (auto it = cache.begin(); it != cache.end(); ++it) {
-            if (it->first == dm->fOffset) {
+            if (it->first == dm->GetOffset()) {
                 if (it->second) {
                     Py_INCREF(it->second);
                     return it->second;
@@ -99,7 +99,7 @@ static PyObject* dm_get(CPPDataMember* dm, CPPInstance* pyobj, PyObject* /* kls 
         bool isLLView = LowLevelView_CheckExact(result);
         if (isLLView && CPPInstance_Check(pyobj)) {
             Py_INCREF(result);
-            pyobj->GetDatamemberCache().push_back(std::make_pair(dm->fOffset, result));
+            pyobj->GetDatamemberCache().push_back(std::make_pair(dm->GetOffset(), result));
             dm->fFlags |= kIsCachable;
         }
 
@@ -152,7 +152,7 @@ static int dm_set(CPPDataMember* dm, CPPInstance* pyobj, PyObject* value)
     if (dm->fFlags & kIsCachable) {
         CPyCppyy::CI_DatamemberCache_t& cache = pyobj->GetDatamemberCache();
         for (auto it = cache.begin(); it != cache.end(); ++it) {
-            if (it->first == dm->fOffset) {
+            if (it->first == dm->GetOffset()) {
                 Py_XDECREF(it->second);
                 cache.erase(it);
                 break;
@@ -233,7 +233,7 @@ static PyObject* dm_reflex(CPPDataMember* dm, PyObject* args)
             return CPyCppyy_PyText_FromString(dm->fFullType.c_str());
     } else if (request == Cppyy::Reflex::OFFSET) {
         if (format == Cppyy::Reflex::OPTIMAL)
-            return PyLong_FromLong(dm->fOffset);
+            return PyLong_FromLong(dm->GetOffset());
     }
 
     PyErr_Format(PyExc_ValueError, "unsupported reflex request %d or format %d", request, format);
@@ -316,11 +316,19 @@ PyTypeObject CPPDataMember_Type = {
 
 
 //- public members -----------------------------------------------------------
+intptr_t CPyCppyy::CPPDataMember::GetOffset()
+{
+    // Calculate the offset again.
+    // The memory leak for `EnumConstantDecl` was fixed in LLVM commit 142f270
+    // We were previosuly relying on the leak to provide the address.
+    return Cppyy::GetDatamemberOffset(fEnclosingScope, fIdata);
+}
+
 void CPyCppyy::CPPDataMember::Set(Cppyy::TCppScope_t scope, Cppyy::TCppIndex_t idata)
 {
     fEnclosingScope = scope;
-    fOffset         = Cppyy::GetDatamemberOffset(scope, idata); // TODO: make lazy
     fFlags          = Cppyy::IsStaticData(scope, idata) ? kIsStaticData : 0;
+    fIdata          = idata;
 
     std::vector<dim_t> dims;
     int ndim = 0; Py_ssize_t size = 0;
@@ -385,7 +393,7 @@ void* CPyCppyy::CPPDataMember::GetAddress(CPPInstance* pyobj)
 {
 // class attributes, global properties
     if (fFlags & kIsStaticData)
-        return (void*)fOffset;
+        return (void *)GetOffset();
 
 // special case: non-static lookup through class
     if (!pyobj) {
@@ -412,7 +420,7 @@ void* CPyCppyy::CPPDataMember::GetAddress(CPPInstance* pyobj)
     if (oisa != fEnclosingScope)
         offset = Cppyy::GetBaseOffset(oisa, fEnclosingScope, obj, 1 /* up-cast */);
 
-    return (void*)((intptr_t)obj + offset + fOffset);
+    return (void *)((intptr_t)obj + offset + GetOffset());
 }
 
 

--- a/src/CPPDataMember.h
+++ b/src/CPPDataMember.h
@@ -23,7 +23,6 @@ public:
 
 public:                 // public, as the python C-API works with C structs
     PyObject_HEAD
-    intptr_t           fOffset;
     Cppyy::TCppIndex_t fIdata;
     long               fFlags;
     Converter*         fConverter;
@@ -63,16 +62,6 @@ inline CPPDataMember* CPPDataMember_New(
     CPPDataMember* pyprop =
         (CPPDataMember*)CPPDataMember_Type.tp_new(&CPPDataMember_Type, nullptr, nullptr);
     pyprop->Set(scope, idata);
-    return pyprop;
-}
-
-inline CPPDataMember* CPPDataMember_NewConstant(
-    Cppyy::TCppScope_t scope, const std::string& name, void* address)
-{
-// Create an initialize a new property descriptor, given the C++ datum.
-    CPPDataMember* pyprop =
-        (CPPDataMember*)CPPDataMember_Type.tp_new(&CPPDataMember_Type, nullptr, nullptr);
-    pyprop->Set(scope, name, address);
     return pyprop;
 }
 

--- a/src/CPPDataMember.h
+++ b/src/CPPDataMember.h
@@ -19,10 +19,12 @@ public:
 
     std::string GetName();
     void* GetAddress(CPPInstance* pyobj /* owner */);
+    intptr_t GetOffset();
 
 public:                 // public, as the python C-API works with C structs
     PyObject_HEAD
     intptr_t           fOffset;
+    Cppyy::TCppIndex_t fIdata;
     long               fFlags;
     Converter*         fConverter;
     Cppyy::TCppScope_t fEnclosingScope;


### PR DESCRIPTION
While working on an update to LLVM 18 for Cling, I found an issue with the following code snippet:

```python
import cppyy

cppyy.cppdef("""\
enum {
    kSingleKey     = 1,
    kOverwrite     = 2,
    kWriteDelete   = 4,
}; """)

print(cppyy.gbl.kSingleKey)
```

This would print garbage values instead of `1` (after the cling update to LLVM18)

This is due to a fix in LLVM 18 that fixes a memory leak [142f270](https://github.com/llvm/llvm-project/commit/142f270c279f2576e4618fc0d1121181c7531fdf). We relied on this memory leak to provide the offset values, but this no longer works after the update.

A draft PR in ROOT to test for performance issues and failing tests: [PR #16000](https://github.com/root-project/root/pull/16000).

There is a temporary fix has been implemented to address the failing tests (in ROOT) for LLVM 18 by reintroducing the memory leak: [de5d141](https://github.com/devajithvs/root/commit/de5d1413e07170e396ac51d982c0844e4f548f4b). But this is better fixed in cppyy.