### PR TITLE
Avoid including "Python.h" in CPyCppyy/API.h

### DIFF
--- a/include/CPyCppyy/API.h
+++ b/include/CPyCppyy/API.h
@@ -1,6 +1,9 @@
 #ifndef CPYCPPYY_API_H
 #define CPYCPPYY_API_H
 
+#include <cstddef>
+#include <cstdint>
+
 //
 // Access to the python interpreter and API onto CPyCppyy.
 //
@@ -23,7 +26,12 @@
 #undef _XOPEN_SOURCE
 #endif
 #endif
-#include "Python.h"
+
+// Forward declare PyObject
+#ifndef PyObject_HEAD
+struct _object;
+typedef _object PyObject;
+#endif
 
 #define CPYCPPYY_VERSION_HEX 0x010c10
 
@@ -87,7 +95,10 @@ struct CallContext;
 // Dimensions class not currently exposed
 #ifndef CPYCPPYY_DIMENSIONS_H
 #define CPYCPPYY_DIMENSIONS_H
-typedef Py_ssize_t dim_t;
+// This Py_ssize_t should be the Py_ssize_t from CPython: a signed size type.
+// This is usually identical to intptr_t, which is verified by a static_assert.
+typedef intptr_t dim_t;
+static_assert(sizeof(dim_t) == sizeof(std::size_t));
 
 class Dimensions {      // Windows note: NOT exported/imported
     dim_t* fDims;

--- a/src/Utility.cxx
+++ b/src/Utility.cxx
@@ -1168,6 +1168,9 @@ bool CPyCppyy::Utility::IncludePython()
         // basic API (converters etc.)
             "#include \"CPyCppyy/API.h\"\n"
 
+        // Python itself
+            "#include \"Python.h\"\n"
+
         // utilities from the CPyCppyy public API
             "#include \"CPyCppyy/DispatchPtr.h\"\n"
             "#include \"CPyCppyy/PyException.h\"\n"


### PR DESCRIPTION
To really replace TPython for good with the CPyCppyy API, the API needs to forward declare PyObject and avoid using other Python typedefs.

Otherwise, the `CPyCppyy/API.h` header can't be included in C++ without adding python-specific include paths like `/usr/include/python3.12/`.

See also:
  * https://mail.python.org/pipermail/python-dev/2003-August/037601.html

I have opened a PR with the same changes in ROOT to see how the ROOT CI is doing with these changes on all platforms:
https://github.com/root-project/root/pull/16019