### PR TITLE
Do not use file globbing in the build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,41 @@ endif()
 
 include_directories("${PROJECT_SOURCE_DIR}/include" "${Python_INCLUDE_DIRS}")
 
-file (GLOB cppyy_src src/*.cxx)
+set(cppyy_src
+    src/API.cxx
+    src/CPPClassMethod.cxx
+    src/CPPConstructor.cxx
+    src/CPPDataMember.cxx
+    src/CPPEnum.cxx
+    src/CPPExcInstance.cxx
+    src/CPPFunction.cxx
+    src/CPPGetSetItem.cxx
+    src/CPPInstance.cxx
+    src/CPPMethod.cxx
+    src/CPPOperator.cxx
+    src/CPPOverload.cxx
+    src/CPPScope.cxx
+    src/CPyCppyyModule.cxx
+    src/CallContext.cxx
+    src/Converters.cxx
+    src/CustomPyTypes.cxx
+    src/DispatchPtr.cxx
+    src/Dispatcher.cxx
+    src/Executors.cxx
+    src/LowLevelViews.cxx
+    src/MemoryRegulator.cxx
+    src/ProxyWrappers.cxx
+    src/PyException.cxx
+    src/PyResult.cxx
+    src/PyStrings.cxx
+    src/Pythonize.cxx
+    src/TPyArg.cxx
+    # src/TPyClassGenerator.cxx # TODO: not sure if this still makes sense
+    src/TemplateProxy.cxx
+    src/TupleOfInstances.cxx
+    src/TypeManip.cxx
+    src/Utility.cxx
+)
 
 add_library(cppyy SHARED ${cppyy_src})
 

--- a/src/TPyClassGenerator.cxx
+++ b/src/TPyClassGenerator.cxx
@@ -6,9 +6,6 @@
 
 #include "CPyCppyy/PyResult.h"
 
-// TODO: not sure if any of this still makes sense ...
-#if 0
-
 // ROOT
 #include "TClass.h"
 #include "TInterpreter.h"
@@ -298,4 +295,3 @@ TClass* TPyClassGenerator::GetClass( const std::type_info& typeinfo, bool load )
 {
    return GetClass( typeinfo.name(), load );
 }
-#endif

--- a/src/TPyClassGenerator.h
+++ b/src/TPyClassGenerator.h
@@ -1,9 +1,6 @@
 #ifndef CPYCPPYY_TPYCLASSGENERATOR
 #define CPYCPPYY_TPYCLASSGENERATOR
 
-// TODO: not sure if any of this still makes sense ...
-#if 0
-
 // ROOT
 #include "TClassGenerator.h"
 
@@ -15,7 +12,5 @@ public:
     virtual TClass* GetClass(const char* name, bool load, bool silent);
     virtual TClass* GetClass(const std::type_info& typeinfo, bool load, bool silent);
 };
-
-#endif
 
 #endif // !CPYCPPYY_TPYCLASSGENERATOR


### PR DESCRIPTION
This makes the build configuration more robust to added and removed files.

See also the analogous PR in ROOT, as well as the corresponding Jira ticket:
  * https://github.com/root-project/root/pull/3259
  * https://its.cern.ch/jira/browse/ROOT-5998

Like this, we also don't need to "comment out" whole source files with preprocessor macros, like the `TPyClassGenerator`. This also helps ROOT, which requires these sources, because then the sources can be used as-is.