### PR TITLE
Avoid holding reference to `__main__` in the CPyCppyy API

### DIFF
--- a/src/API.cxx
+++ b/src/API.cxx
@@ -88,7 +88,10 @@ static bool Initialize()
     // retrieve the main dictionary
         gMainDict = PyModule_GetDict(
             PyImport_AddModule(const_cast<char*>("__main__")));
-        Py_INCREF(gMainDict);
+    // The gMainDict is borrowed, i.e. we are not calling Py_INCREF(gMainDict).
+    // Like this, we avoid unexpectedly affecting how long __main__ is kept
+    // alive. The gMainDict is only used in Exec(), ExecScript(), and Eval(),
+    // which should not be called after __main__ is garbage collected anyway.
     }
 
 // declare success ...


### PR DESCRIPTION
The `gMainDict` should be borrowed, i.e. we are not calling Py_INCREF(gMainDict). Like this, we avoid unexpectedly affecting how long `__main__` is kept alive. The `gMainDict` is only used in `Exec()`, `ExecScript()`, and `Eval()`, which should not be called after `__main__` is garbage collected anyway.

Equivalent ROOT PR with the CI run:
https://github.com/root-project/root/pull/16403