### PR TITLE
No static gPythonizations variable to avoid initialization order fiasco

### DIFF
--- a/src/CPPInstance.cxx
+++ b/src/CPPInstance.cxx
@@ -441,7 +441,7 @@ static int op_clear(CPPInstance* pyobj)
 // Garbage collector clear of held python member objects; this is a good time
 // to safely remove this object from the memory regulator.
     if (pyobj->fFlags & CPPInstance::kIsRegulated)
-        MemoryRegulator::UnregisterPyObject(pyobj, (PyObject*)Py_TYPE((PyObject*)pyobj));;
+        MemoryRegulator::UnregisterPyObject(pyobj, (PyObject*)Py_TYPE((PyObject*)pyobj));
 
     return 0;
 }

--- a/src/CPyCppyyModule.cxx
+++ b/src/CPyCppyyModule.cxx
@@ -236,10 +236,15 @@ namespace CPyCppyy {
     PyObject* gSegvException = nullptr;
     PyObject* gIllException  = nullptr;
     PyObject* gAbrtException = nullptr;
-    std::map<std::string, std::vector<PyObject*>> gPythonizations;
     std::set<Cppyy::TCppType_t> gPinnedTypes;
     std::ostringstream gCapturedError;
     std::streambuf* gOldErrorBuffer = nullptr;
+
+    std::map<std::string, std::vector<PyObject*>> &pythonizations()
+    {
+       static std::map<std::string, std::vector<PyObject*>> pyzMap;
+       return pyzMap;
+    }
 }
 
 
@@ -824,7 +829,7 @@ static PyObject* AddPythonization(PyObject*, PyObject* args)
     }
 
     Py_INCREF(pythonizor);
-    gPythonizations[scope].push_back(pythonizor);
+    pythonizations()[scope].push_back(pythonizor);
 
     Py_RETURN_NONE;
 }
@@ -838,8 +843,9 @@ static PyObject* RemovePythonization(PyObject*, PyObject* args)
     if (!PyArg_ParseTuple(args, const_cast<char*>("Os"), &pythonizor, &scope))
         return nullptr;
 
-    auto p1 = gPythonizations.find(scope);
-    if (p1 != gPythonizations.end()) {
+    auto &pyzMap = pythonizations();
+    auto p1 = pyzMap.find(scope);
+    if (p1 != pyzMap.end()) {
         auto p2 = std::find(p1->second.begin(), p1->second.end(), pythonizor);
         if (p2 != p1->second.end()) {
             p1->second.erase(p2);

--- a/src/Executors.cxx
+++ b/src/Executors.cxx
@@ -746,7 +746,7 @@ PyObject* CPyCppyy::InstancePtrRefExecutor::Execute(
         return BindCppObject(*result, fClass);
 
     CPPInstance* cppinst = (CPPInstance*)fAssignable;
-    *result = cppinst->GetObject();;
+    *result = cppinst->GetObject();
 
     Py_DECREF(fAssignable);
     fAssignable = nullptr;

--- a/src/Pythonize.cxx
+++ b/src/Pythonize.cxx
@@ -26,7 +26,7 @@
 //- data and local helpers ---------------------------------------------------
 namespace CPyCppyy {
     extern PyObject* gThisModule;
-    extern std::map<std::string, std::vector<PyObject*>> gPythonizations;
+    std::map<std::string, std::vector<PyObject*>> &pythonizations();
 }
 
 namespace {
@@ -1957,9 +1957,10 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
 // the global ones (the idea is to allow writing a pythonizor that see all classes)
     bool pstatus = true;
     std::string outer_scope = TypeManip::extract_namespace(name);
+    auto &pyzMap = pythonizations();
     if (!outer_scope.empty()) {
-        auto p = gPythonizations.find(outer_scope);
-        if (p != gPythonizations.end()) {
+        auto p = pyzMap.find(outer_scope);
+        if (p != pyzMap.end()) {
             PyObject* subname = CPyCppyy_PyText_FromString(
                 name.substr(outer_scope.size()+2, std::string::npos).c_str());
             pstatus = run_pythonizors(pyclass, subname, p->second);
@@ -1968,8 +1969,8 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
     }
 
     if (pstatus) {
-        auto p = gPythonizations.find("");
-        if (p != gPythonizations.end())
+        auto p = pyzMap.find("");
+        if (p != pyzMap.end())
             pstatus = run_pythonizors(pyclass, pyname, p->second);
     }
 


### PR DESCRIPTION
No static `gPythonizations` variable to avoid static initialization order fiasco. This avoids some crashes when using `TPython` in compiled code.

This is necessary to make a newly suggested TPython multithreading unit test work:
https://github.com/root-project/root/pull/16427