### PR TITLE
Drop `*` in `TypeManip` when changing scope to legal name

### DIFF
--- a/src/TypeManip.cxx
+++ b/src/TypeManip.cxx
@@ -190,7 +190,7 @@ void CPyCppyy::TypeManip::cppscope_to_legalname(std::string& cppscope)
 {
 // Change characters illegal in a variable name into '_' to form a legal name.
     for (char& c : cppscope) {
-        for (char needle : {':', '>', '<', ' ', ',', '&', '='})
+        for (char needle : {':', '>', '<', ' ', ',', '&', '=', '*'})
             if (c == needle) c = '_';
     }
 }


### PR DESCRIPTION
Prevents illegal function names in generated code stitched together by the [aggregate initializer](https://github.com/wlav/CPyCppyy/blob/ecd1d0c350761d7bbd7d0f670293d82137f51b79/src/Pythonize.cxx#L1719)

See related PR with the failing tests: https://github.com/root-project/root/pull/16338/