### PR TITLE
Also replace `*` in cppscope_to_legalname

### DIFF
--- a/src/TypeManip.cxx
+++ b/src/TypeManip.cxx
@@ -190,7 +190,7 @@ void CPyCppyy::TypeManip::cppscope_to_legalname(std::string& cppscope)
 {
 // Change characters illegal in a variable name into '_' to form a legal name.
     for (char& c : cppscope) {
-        for (char needle : {':', '>', '<', ' ', ',', '&', '='})
+        for (char needle : {':', '>', '<', ' ', ',', '&', '=', '*'})
             if (c == needle) c = '_';
     }
 }


### PR DESCRIPTION
This fixes ROOT test failues when using the initializer list pythonization.

See: https://github.com/root-project/root/pull/16338.