### PR TITLE
Initialize new PyTypeObject fields introduced in Python 3.13

### DIFF
--- a/src/CPPDataMember.cxx
+++ b/src/CPPDataMember.cxx
@@ -310,6 +310,9 @@ PyTypeObject CPPDataMember_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/CPPExcInstance.cxx
+++ b/src/CPPExcInstance.cxx
@@ -288,6 +288,9 @@ PyTypeObject CPPExcInstance_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                            // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                            // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/CPPInstance.cxx
+++ b/src/CPPInstance.cxx
@@ -1102,6 +1102,9 @@ PyTypeObject CPPInstance_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/CPPOverload.cxx
+++ b/src/CPPOverload.cxx
@@ -1055,6 +1055,9 @@ PyTypeObject CPPOverload_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                                // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                                // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/CPPScope.cxx
+++ b/src/CPPScope.cxx
@@ -707,6 +707,9 @@ PyTypeObject CPPScope_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/CPyCppyyModule.cxx
+++ b/src/CPyCppyyModule.cxx
@@ -164,6 +164,9 @@ static PyTypeObject PyNullPtr_t_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                  // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                  // tp_versions_used
+#endif
 };
 
 
@@ -203,6 +206,9 @@ static PyTypeObject PyDefault_t_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                 // tp_watched
+#endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                 // tp_versions_used
 #endif
 };
 

--- a/src/CustomPyTypes.cxx
+++ b/src/CustomPyTypes.cxx
@@ -170,6 +170,9 @@ PyTypeObject TypedefPointerToClass_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
+#endif
 };
 
 //= instancemethod object with a more efficient call function ================
@@ -341,6 +344,9 @@ PyTypeObject CustomInstanceMethod_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
+#endif
 };
 
 
@@ -397,6 +403,9 @@ PyTypeObject IndexIter_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
+#endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
 #endif
 };
 
@@ -465,6 +474,9 @@ PyTypeObject VectorIter_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
+#endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
 #endif
 };
 

--- a/src/LowLevelViews.cxx
+++ b/src/LowLevelViews.cxx
@@ -959,6 +959,9 @@ PyTypeObject LowLevelView_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                            // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                            // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/TemplateProxy.cxx
+++ b/src/TemplateProxy.cxx
@@ -960,6 +960,9 @@ PyTypeObject TemplateProxy_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                                // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                                // tp_versions_used
+#endif
 };
 
 } // namespace CPyCppyy

--- a/src/TupleOfInstances.cxx
+++ b/src/TupleOfInstances.cxx
@@ -120,6 +120,9 @@ PyTypeObject InstanceArrayIter_Type = {
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
 #endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
+#endif
 };
 
 
@@ -253,6 +256,9 @@ PyTypeObject TupleOfInstances_Type = {
 #endif
 #if PY_VERSION_HEX >= 0x030c0000
     , 0                           // tp_watched
+#endif
+#if PY_VERSION_HEX >= 0x030d0000
+    , 0                           // tp_versions_used
 #endif
 };
 


### PR DESCRIPTION
This is to avoid compiler warnings, as usual.

Identical PR in ROOT: https://github.com/root-project/root/pull/16780