### PR TITLE
Use PyMapping_GetOptionalItemString where necessary with Python 3.13

### DIFF
--- a/src/Dispatcher.cxx
+++ b/src/Dispatcher.cxx
@@ -484,7 +484,12 @@ bool CPyCppyy::InsertDispatcher(CPPScope* klass, PyObject* bases, PyObject* dct,
 // Python class to keep the inheritance tree intact)
     for (const auto& name : protected_names) {
          PyObject* disp_dct = PyObject_GetAttr(disp_proxy, PyStrings::gDict);
+#if PY_VERSION_HEX < 0x30d00f0
          PyObject* pyf = PyMapping_GetItemString(disp_dct, (char*)name.c_str());
+#else
+         PyObject* pyf = nullptr;
+         PyMapping_GetOptionalItemString(disp_dct, (char*)name.c_str(), &pyf);
+#endif
          if (pyf) {
              PyObject_SetAttrString((PyObject*)klass, (char*)name.c_str(), pyf);
              Py_DECREF(pyf);


### PR DESCRIPTION
With Python 3.13, some lookup methods like `PyMapping_GetItemString` and `PyObject_GetAttrString` became more strict. They are now always throwing an exception in case the attribute is not found.

To make these optional lookups work again, the `GetOptional` family of functions needs to be used.

See:
  * https://docs.python.org/3/c-api/object.html#c.PyObject_GetOptionalAttrString
  * https://docs.python.org/3/c-api/mapping.html#c.PyMapping_GetOptionalItemString

This is the upstream version of the following ROOT commit:

  * https://github.com/root-project/root/commit/0a823d99ee

Related to the following **cppyy issue**, although it might be better to close that issue by fixing the underlying problem:
  * https://github.com/wlav/cppyy/issues/273