### PR TITLE
Avoid `nullptr` dereferencing in CPyCppyy::BindCppObjectNoCast

### DIFF
--- a/src/CPPMethod.cxx
+++ b/src/CPPMethod.cxx
@@ -611,8 +611,6 @@ PyObject* CPyCppyy::CPPMethod::GetArgDefault(int iarg, bool silent)
         PyObject* gdct = *dctptr;
         PyObject* scope = nullptr;
 
-        std::string possible_scope = defvalue.substr(0, defvalue.rfind('('));
-
         if (defvalue.rfind('(') != std::string::npos) {    // constructor-style call
         // try to tickle scope creation, just in case, first look in the scope where
         // the function lives, then in the global scope

--- a/src/ProxyWrappers.cxx
+++ b/src/ProxyWrappers.cxx
@@ -836,7 +836,7 @@ PyObject* CPyCppyy::BindCppObjectNoCast(Cppyy::TCppObject_t address,
 
     bool noReg      = flags & (CPPInstance::kNoMemReg|CPPInstance::kNoWrapConv);
     bool isRef      = flags & CPPInstance::kIsReference;
-    void* r_address = isRef ? *(void**)address : address;
+    void* r_address = isRef ? (address ? *(void**)address : nullptr) : address;
 
 // check whether the object to be bound is a smart pointer that needs embedding
     PyObject* smart_type = (!(flags & CPPInstance::kNoWrapConv) && \


### PR DESCRIPTION
Closes the following issue:

  * https://github.com/wlav/cppyy/issues/281