### PR TITLE
Preserve Python errors when executing C++ function

### DIFF
--- a/src/API.cxx
+++ b/src/API.cxx
@@ -226,7 +226,7 @@ bool CPyCppyy::Instance_IsLively(PyObject* pyobject)
 
 // the instance fails the lively test if it owns the C++ object while having a
 // reference count of 1 (meaning: it could delete the C++ instance any moment)
-    if (pyobject->ob_refcnt <= 1 && (((CPPInstance*)pyobject)->fFlags & CPPInstance::kIsOwner))
+    if (Py_REFCNT(pyobject) <= 1 && (((CPPInstance*)pyobject)->fFlags & CPPInstance::kIsOwner))
         return false;
 
     return true;

--- a/src/CPPOperator.cxx
+++ b/src/CPPOperator.cxx
@@ -2,6 +2,7 @@
 #include "CPyCppyy.h"
 #include "CPPOperator.h"
 #include "CPPInstance.h"
+#include "Utility.h"
 
 
 //- constructor --------------------------------------------------------------
@@ -49,17 +50,14 @@ PyObject* CPyCppyy::CPPOperator::Call(CPPInstance*& self,
         return result;
     }
 
-    PyObject* pytype = 0, *pyvalue = 0, *pytrace = 0;
-    PyErr_Fetch(&pytype, &pyvalue, &pytrace);
+// fetch the current error, resetting the error buffer
+    auto error = CPyCppyy::Utility::FetchPyError();
 
     result = fStub((PyObject*)self, CPyCppyy_PyArgs_GET_ITEM(args, idx_other));
 
-    if (!result)
-        PyErr_Restore(pytype, pyvalue, pytrace);
-    else {
-        Py_XDECREF(pytype);
-        Py_XDECREF(pyvalue);
-        Py_XDECREF(pytrace);
+// if there was still a problem, restore the Python error buffer
+    if (!result) {
+        CPyCppyy::Utility::RestorePyError(error);
     }
 
     return result;

--- a/src/CPPOverload.cxx
+++ b/src/CPPOverload.cxx
@@ -712,9 +712,6 @@ static PyObject* mp_call(CPPOverload* pymeth, PyObject* args, PyObject* kwds)
                     }
                 }
 
-            // clear collected errors
-                if (!errors.empty())
-                    std::for_each(errors.begin(), errors.end(), Utility::PyError_t::Clear);
                 return HandleReturn(pymeth, im_self, result);
             }
 
@@ -758,7 +755,7 @@ static PyObject* mp_call(CPPOverload* pymeth, PyObject* args, PyObject* kwds)
 // first summarize, then add details
     PyObject* topmsg = CPyCppyy_PyText_FromFormat(
         "none of the %d overloaded methods succeeded. Full details:", (int)nMethods);
-    SetDetailedException(errors, topmsg /* steals */, PyExc_TypeError /* default error */);
+    SetDetailedException(std::move(errors), topmsg /* steals */, PyExc_TypeError /* default error */);
 
 // report failure
     return nullptr;

--- a/src/CPPOverload.h
+++ b/src/CPPOverload.h
@@ -25,7 +25,7 @@ inline uint64_t HashSignature(CPyCppyy_PyArgs_t args, size_t nargsf)
     // improved overloads for implicit conversions
         PyObject* pyobj = CPyCppyy_PyArgs_GET_ITEM(args, i);
         hash += (uint64_t)Py_TYPE(pyobj);
-        hash += (uint64_t)(pyobj->ob_refcnt == 1 ? 1 : 0);
+        hash += (uint64_t)(Py_REFCNT(pyobj) == 1 ? 1 : 0);
         hash += (hash << 10); hash ^= (hash >> 6);
     }
 

--- a/src/CPPScope.cxx
+++ b/src/CPPScope.cxx
@@ -504,7 +504,6 @@ static PyObject* meta_getattro(PyObject* pyclass, PyObject* pyname)
     }
 
     if (attr) {
-        std::for_each(errors.begin(), errors.end(), Utility::PyError_t::Clear);
         PyErr_Clear();
     } else {
     // not found: prepare a full error report
@@ -518,7 +517,7 @@ static PyObject* meta_getattro(PyObject* pyclass, PyObject* pyname)
             topmsg = CPyCppyy_PyText_FromFormat("no such attribute \'%s\'. Full details:",
                 CPyCppyy_PyText_AsString(pyname));
         }
-        SetDetailedException(errors, topmsg /* steals */, PyExc_AttributeError /* default error */);
+        SetDetailedException(std::move(errors), topmsg /* steals */, PyExc_AttributeError /* default error */);
     }
 
     return attr;

--- a/src/CPyCppyyModule.cxx
+++ b/src/CPyCppyyModule.cxx
@@ -214,23 +214,13 @@ static PyTypeObject PyDefault_t_Type = {
 
 namespace {
 
-PyObject _CPyCppyy_NullPtrStruct = {_PyObject_EXTRA_INIT
-// In 3.12.0-beta this field was changed from a ssize_t to a union
-#if PY_VERSION_HEX >= 0x30c00b1
-                                    {1},
-#else
-                                    1,
-#endif
-                                    &PyNullPtr_t_Type};
+struct {
+   PyObject_HEAD
+} _CPyCppyy_NullPtrStruct{PyObject_HEAD_INIT(&PyNullPtr_t_Type)};
 
-PyObject _CPyCppyy_DefaultStruct = {_PyObject_EXTRA_INIT
-// In 3.12.0-beta this field was changed from a ssize_t to a union
-#if PY_VERSION_HEX >= 0x30c00b1
-                                    {1},
-#else
-                                    1,
-#endif
-                                    &PyDefault_t_Type};
+struct {
+   PyObject_HEAD
+} _CPyCppyy_DefaultStruct{PyObject_HEAD_INIT(&PyDefault_t_Type)};
 
 // TODO: refactor with Converters.cxx
 struct CPyCppyy_tagCDataObject {       // non-public (but stable)
@@ -779,7 +769,7 @@ static PyObject* BindObject(PyObject*, PyObject* args, PyObject* kwds)
 
 // not a pre-existing object; get the address and bind
     void* addr = nullptr;
-    if (arg0 != &_CPyCppyy_NullPtrStruct) {
+    if (arg0 != gNullPtrObject) {
         addr = CPyCppyy_PyCapsule_GetPointer(arg0, nullptr);
         if (PyErr_Occurred()) {
             PyErr_Clear();

--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -535,10 +535,9 @@ bool CPyCppyy::Converter::ToMemory(PyObject*, void*, PyObject* /* ctxt */)
     if (val == (type)-1 && PyErr_Occurred()) {                               \
         static PyTypeObject* ctypes_type = nullptr;                          \
         if (!ctypes_type) {                                                  \
-            PyObject* pytype = 0, *pyvalue = 0, *pytrace = 0;                \
-            PyErr_Fetch(&pytype, &pyvalue, &pytrace);                        \
+            auto error = CPyCppyy::Utility::FetchPyError();                  \
             ctypes_type = GetCTypesType(ct_##ctype);                         \
-            PyErr_Restore(pytype, pyvalue, pytrace);                         \
+            CPyCppyy::Utility::RestorePyError(error);                        \
         }                                                                    \
         if (Py_TYPE(pyobject) == ctypes_type) {                              \
             PyErr_Clear();                                                   \
@@ -1258,16 +1257,14 @@ bool CPyCppyy::CStringConverter::SetArg(
     const char* cstr = CPyCppyy_PyText_AsStringAndSize(pyobject, &len);
     if (!cstr) {
     // special case: allow ctypes c_char_p
-        PyObject* pytype = 0, *pyvalue = 0, *pytrace = 0;
-        PyErr_Fetch(&pytype, &pyvalue, &pytrace);
+        auto error = CPyCppyy::Utility::FetchPyError();
         if (Py_TYPE(pyobject) == GetCTypesType(ct_c_char_p)) {
             SetLifeLine(ctxt->fPyContext, pyobject, (intptr_t)this);
             para.fValue.fVoidp = (void*)((CPyCppyy_tagCDataObject*)pyobject)->b_ptr;
             para.fTypeCode = 'V';
-            Py_XDECREF(pytype); Py_XDECREF(pyvalue); Py_XDECREF(pytrace);
             return true;
         }
-        PyErr_Restore(pytype, pyvalue, pytrace);
+        CPyCppyy::Utility::RestorePyError(error);
         return false;
     }
 

--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -2069,7 +2069,7 @@ bool CPyCppyy::STLStringMoveConverter::SetArg(
         if (pyobj->fFlags & CPPInstance::kIsRValue) {
             pyobj->fFlags &= ~CPPInstance::kIsRValue;
             moveit_reason = 2;
-        } else if (pyobject->ob_refcnt <= MOVE_REFCOUNT_CUTOFF) {
+        } else if (Py_REFCNT(pyobject) <= MOVE_REFCOUNT_CUTOFF) {
             moveit_reason = 1;
         } else
             moveit_reason = 0;
@@ -2306,7 +2306,7 @@ bool CPyCppyy::InstanceMoveConverter::SetArg(
     if (pyobj->fFlags & CPPInstance::kIsRValue) {
         pyobj->fFlags &= ~CPPInstance::kIsRValue;
         moveit_reason = 2;
-    } else if (pyobject->ob_refcnt <= MOVE_REFCOUNT_CUTOFF) {
+    } else if (Py_REFCNT(pyobject) <= MOVE_REFCOUNT_CUTOFF) {
         moveit_reason = 1;
     }
 

--- a/src/Pythonize.cxx
+++ b/src/Pythonize.cxx
@@ -549,7 +549,7 @@ static PyObject* vector_iter(PyObject* v) {
 
 // tell the iterator code to set a life line if this container is a temporary
     vi->vi_flags = vectoriterobject::kDefault;
-    if (v->ob_refcnt <= 2 || (((CPPInstance*)v)->fFlags & CPPInstance::kIsValue))
+    if (Py_REFCNT(v) <= 2 || (((CPPInstance*)v)->fFlags & CPPInstance::kIsValue))
         vi->vi_flags = vectoriterobject::kNeedLifeLine;
 
     PyObject* pyvalue_type = PyObject_GetAttr((PyObject*)Py_TYPE(v), PyStrings::gValueType);


### PR DESCRIPTION
Upstream version of the following ROOT PRs:
  * https://github.com/root-project/root/pull/18163
  * https://github.com/root-project/root/pull/18179
  * https://github.com/root-project/root/pull/18149

Only the first commit changes behavior. Here is the motivation.

The internal `CPyCppyy::CPPMethod::SetPyError_()` method currently
handles three different cases related to method calls:

1. When there is something wrong with the arguments or any other problem
   when setting up the function call, `CPyCppyy` itself will set a **new
   error**. Example usage in
   [VerifyArgCount_](https://github.com/root-project/root/blob/master/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx#L75)..
2. Adding context information when dealing with a **C++ exception** when
   [calling the
   function](https://github.com/root-project/root/blob/master/bindings/pyroot/cppyy/CPyCppyy/src/CPPMethod.cxx#L981).
3. Dealing with a **Python error** when executing the function. In this
   case, the current logic resets the exception to something that looks
   like the C++ exception, only mentioning the current `CPPMethod` and
   the final exception message. However, that means that all the
   traceback between the `CPPMethod` and the place where the error
   occurred is lost, although it was available.

This commit suggests to make the third case of dealing with a Python
exception a no-op. Like this, we keep the already very informative
Python traceback. There is only one drawback: the exception is not
augmented with information on the C++ method anymore. But given that in
case of a Python error, getting info on the Python code and traceback is
more important than getting info on the C++ side, this seems to me an
acceptable price to pay.

The motivation for this change is that Python callbacks passed to the
C++ side are increasingly common, and one doesn't want to be blind in
case of errors.

Also, refactor a code to match the `PyErr_Fetch` with a `PyErr_Restore`
when appropriate, as recommended by the Python C API documentation.

Closes ROOT issue https://github.com/root-project/root/issues/18146.

Simple demo based on the code example in the issue:
```python
import ROOT

def inner_func(x):
    raise ValueError("hello")

def func(x):
    return inner_func(x)

cpp_wrapper = ROOT.std.function["double(double)"](func)

cpp_wrapper(3)
```
Without this PR
```
Traceback (most recent call last):
  File "script.py", line 48, in main
    cpp_wrapper_1(3)
    ^^^^^^^^^^^^^^^^
ValueError: double std::function<double(double)>::operator()(double __args) =>
    ValueError: hello
```
With this PR:
```
Traceback (most recent call last):
  File "script.py", line 11, in <module>
    cpp_wrapper(3)
  File "script.py", line 7, in func
    return inner_func(x)
           ^^^^^^^^^^^^^
  File "script.py", line 4, in inner_func
    raise ValueError("hello")
ValueError: hello
```