### PR TITLE
Correct check for temporaries in Python 3.14

### DIFF
--- a/src/CPPOverload.h
+++ b/src/CPPOverload.h
@@ -25,7 +25,11 @@ inline uint64_t HashSignature(CPyCppyy_PyArgs_t args, size_t nargsf)
     // improved overloads for implicit conversions
         PyObject* pyobj = CPyCppyy_PyArgs_GET_ITEM(args, i);
         hash += (uint64_t)Py_TYPE(pyobj);
-        hash += (uint64_t)(pyobj->ob_refcnt == 1 ? 1 : 0);
+#if PY_VERSION_HEX >= 0x030e0000
+        hash += (uint64_t)(PyUnstable_Object_IsUniqueReferencedTemporary(pyobj) ? 1 : 0);
+#else
+        hash += (uint64_t)(Py_REFCNT(pyobj) == 1 ? 1 : 0);
+#endif
         hash += (hash << 10); hash ^= (hash >> 6);
     }
 

--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -61,6 +61,9 @@ namespace CPyCppyy {
     static std::regex s_fnptr("\\((\\w*:*)*\\*&*\\)");
 }
 
+// Define our own PyUnstable_Object_IsUniqueReferencedTemporary function if the
+// Python version is lower than 3.14, the version where that function got introduced.
+#if PY_VERSION_HEX < 0x030e0000
 #if PY_VERSION_HEX < 0x03000000
 const Py_ssize_t MOVE_REFCOUNT_CUTOFF = 1;
 #elif PY_VERSION_HEX < 0x03080000
@@ -72,6 +75,10 @@ const Py_ssize_t MOVE_REFCOUNT_CUTOFF = 2;
 #else
 // since py3.8, vector calls behave again as expected
 const Py_ssize_t MOVE_REFCOUNT_CUTOFF = 1;
+#endif
+inline bool PyUnstable_Object_IsUniqueReferencedTemporary(PyObject *pyobject) {
+    return Py_REFCNT(pyobject) <= MOVE_REFCOUNT_CUTOFF;
+}
 #endif
 
 //- pretend-ctypes helpers ---------------------------------------------------
@@ -2071,7 +2078,7 @@ bool CPyCppyy::STLStringMoveConverter::SetArg(
         if (pyobj->fFlags & CPPInstance::kIsRValue) {
             pyobj->fFlags &= ~CPPInstance::kIsRValue;
             moveit_reason = 2;
-        } else if (pyobject->ob_refcnt <= MOVE_REFCOUNT_CUTOFF) {
+        } else if (PyUnstable_Object_IsUniqueReferencedTemporary(pyobject)) {
             moveit_reason = 1;
         } else
             moveit_reason = 0;
@@ -2308,7 +2315,7 @@ bool CPyCppyy::InstanceMoveConverter::SetArg(
     if (pyobj->fFlags & CPPInstance::kIsRValue) {
         pyobj->fFlags &= ~CPPInstance::kIsRValue;
         moveit_reason = 2;
-    } else if (pyobject->ob_refcnt <= MOVE_REFCOUNT_CUTOFF) {
+    } else if (PyUnstable_Object_IsUniqueReferencedTemporary(pyobject)) {
         moveit_reason = 1;
     }
 

--- a/src/Pythonize.cxx
+++ b/src/Pythonize.cxx
@@ -544,13 +544,18 @@ static PyObject* vector_iter(PyObject* v) {
     vectoriterobject* vi = PyObject_GC_New(vectoriterobject, &VectorIter_Type);
     if (!vi) return nullptr;
 
-    Py_INCREF(v);
     vi->ii_container = v;
 
 // tell the iterator code to set a life line if this container is a temporary
     vi->vi_flags = vectoriterobject::kDefault;
-    if (v->ob_refcnt <= 2 || (((CPPInstance*)v)->fFlags & CPPInstance::kIsValue))
+#if PY_VERSION_HEX >= 0x030e0000
+    if (PyUnstable_Object_IsUniqueReferencedTemporary(v) || (((CPPInstance*)v)->fFlags & CPPInstance::kIsValue))
+#else
+    if (Py_REFCNT(v) <= 1 || (((CPPInstance*)v)->fFlags & CPPInstance::kIsValue))
+#endif
         vi->vi_flags = vectoriterobject::kNeedLifeLine;
+
+    Py_INCREF(v);
 
     PyObject* pyvalue_type = PyObject_GetAttr((PyObject*)Py_TYPE(v), PyStrings::gValueType);
     if (pyvalue_type) {


### PR DESCRIPTION
According to the Python release notes, the correct way to check for temporaries is to use the new
[PyUnstable_Object_IsUniqueReferencedTemporary()](https://docs.python.org/3.14/c-api/object.html#c.PyUnstable_Object_IsUniqueReferencedTemporary).

See in particular the "Porting to Python 3.14" section in the release notes:
https://docs.python.org/3.14/whatsnew/3.14.html#id12

This fixes several failures in the `cppyy/test/test_cpp11features.py` test with Python 3.14.

Tested locally with a Python 3.14 build.

This is equivalent to the following PR in ROOT:
https://github.com/root-project/root/pull/19017