### PR TITLE
Add missing `override` keywords

### DIFF
--- a/src/CPPClassMethod.h
+++ b/src/CPPClassMethod.h
@@ -12,12 +12,12 @@ public:
     using CPPMethod::CPPMethod;
 
 public:
-    virtual PyObject* GetTypeName();
+    PyObject* GetTypeName() override;
 
 public:
-    virtual PyCallable* Clone() { return new CPPClassMethod(*this); }
-    virtual PyObject* Call(CPPInstance*& self,
-        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr);
+    PyCallable* Clone() override { return new CPPClassMethod(*this); }
+    PyObject* Call(CPPInstance*& self,
+        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr) override;
 };
 
 } // namespace CPyCppyy

--- a/src/CPPConstructor.h
+++ b/src/CPPConstructor.h
@@ -12,16 +12,16 @@ public:
     using CPPMethod::CPPMethod;
 
 public:
-    virtual PyObject* GetDocString();
-    virtual PyObject* Reflex(Cppyy::Reflex::RequestId_t,
-                             Cppyy::Reflex::FormatId_t = Cppyy::Reflex::OPTIMAL);
+    PyObject* GetDocString() override;
+    PyObject* Reflex(Cppyy::Reflex::RequestId_t,
+                             Cppyy::Reflex::FormatId_t = Cppyy::Reflex::OPTIMAL) override;
 
-    virtual PyCallable* Clone() { return new CPPConstructor(*this); }
-    virtual PyObject* Call(CPPInstance*& self,
-        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr);
+    PyCallable* Clone() override { return new CPPConstructor(*this); }
+    PyObject* Call(CPPInstance*& self,
+        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr) override;
 
 protected:
-    virtual bool InitExecutor_(Executor*&, CallContext* ctxt = nullptr);
+    bool InitExecutor_(Executor*&, CallContext* ctxt = nullptr) override;
 };
 
 
@@ -33,9 +33,9 @@ public:
     CPPMultiConstructor& operator=(const CPPMultiConstructor&);
 
 public:
-    virtual PyCallable* Clone() { return new CPPMultiConstructor(*this); }
-    virtual PyObject* Call(CPPInstance*& self,
-        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr);
+    PyCallable* Clone() override { return new CPPMultiConstructor(*this); }
+    PyObject* Call(CPPInstance*& self,
+        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr) override;
 
 private:
     Py_ssize_t fNumBases;
@@ -48,9 +48,9 @@ public:
     using CPPConstructor::CPPConstructor;
 
 public:
-    virtual PyCallable* Clone() { return new CPPAbstractClassConstructor(*this); }
-    virtual PyObject* Call(CPPInstance*& self,
-        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr);
+    PyCallable* Clone() override { return new CPPAbstractClassConstructor(*this); }
+    PyObject* Call(CPPInstance*& self,
+        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr) override;
 };
 
 class CPPNamespaceConstructor : public CPPConstructor {
@@ -58,9 +58,9 @@ public:
     using CPPConstructor::CPPConstructor;
 
 public:
-    virtual PyCallable* Clone() { return new CPPNamespaceConstructor(*this); }
-    virtual PyObject* Call(CPPInstance*& self,
-        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr);
+    PyCallable* Clone() override { return new CPPNamespaceConstructor(*this); }
+    PyObject* Call(CPPInstance*& self,
+        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr) override;
 };
 
 class CPPIncompleteClassConstructor : public CPPConstructor {
@@ -68,9 +68,9 @@ public:
     using CPPConstructor::CPPConstructor;
 
 public:
-    virtual PyCallable* Clone() { return new CPPIncompleteClassConstructor(*this); }
-    virtual PyObject* Call(CPPInstance*& self,
-        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr);
+    PyCallable* Clone() override { return new CPPIncompleteClassConstructor(*this); }
+    PyObject* Call(CPPInstance*& self,
+        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr) override;
 };
 
 class CPPAllPrivateClassConstructor : public CPPConstructor {
@@ -78,9 +78,9 @@ public:
     using CPPConstructor::CPPConstructor;
 
 public:
-    virtual PyCallable* Clone() { return new CPPAllPrivateClassConstructor(*this); }
-    virtual PyObject* Call(CPPInstance*& self,
-        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr);
+    PyCallable* Clone() override { return new CPPAllPrivateClassConstructor(*this); }
+    PyObject* Call(CPPInstance*& self,
+        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr) override;
 };
 
 } // namespace CPyCppyy

--- a/src/CPPFunction.h
+++ b/src/CPPFunction.h
@@ -13,15 +13,15 @@ public:
     using CPPMethod::CPPMethod;
 
 public:
-    virtual PyObject* GetTypeName();
+    PyObject* GetTypeName() override;
 
 public:
-    virtual PyCallable* Clone() { return new CPPFunction(*this); }
-    virtual PyObject* Call(CPPInstance*& self,
-        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr);
+    PyCallable* Clone() override { return new CPPFunction(*this); }
+    PyObject* Call(CPPInstance*& self,
+        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr) override;
 
 protected:
-    virtual bool ProcessArgs(PyCallArgs& args);
+    bool ProcessArgs(PyCallArgs& args) override;
 };
 
 // Wrapper for global binary operators that swap arguments
@@ -29,12 +29,12 @@ class CPPReverseBinary : public CPPFunction {
 public:
     using CPPFunction::CPPFunction;
 
-    virtual PyCallable* Clone() { return new CPPFunction(*this); }
-    virtual PyObject* Call(CPPInstance*& self,
-        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr);
+    PyCallable* Clone() override { return new CPPFunction(*this); }
+    PyObject* Call(CPPInstance*& self,
+        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr) override;
 
 protected:
-    virtual bool ProcessArgs(PyCallArgs& args);
+    bool ProcessArgs(PyCallArgs& args) override;
 };
 
 // Helper to add self to the arguments tuple if rebound

--- a/src/CPPGetSetItem.h
+++ b/src/CPPGetSetItem.h
@@ -12,11 +12,11 @@ public:
     using CPPMethod::CPPMethod;
 
 public:
-    virtual PyCallable* Clone() { return new CPPSetItem(*this); }
+    PyCallable* Clone() override { return new CPPSetItem(*this); }
 
 protected:
-    virtual bool ProcessArgs(PyCallArgs& args);
-    virtual bool InitExecutor_(Executor*&, CallContext* ctxt = nullptr);
+    bool ProcessArgs(PyCallArgs& args) override;
+    bool InitExecutor_(Executor*&, CallContext* ctxt = nullptr) override;
 };
 
 class CPPGetItem : public CPPMethod {
@@ -24,10 +24,10 @@ public:
     using CPPMethod::CPPMethod;
 
 public:
-    virtual PyCallable* Clone() { return new CPPGetItem(*this); }
+    PyCallable* Clone() override { return new CPPGetItem(*this); }
 
 protected:
-    virtual bool ProcessArgs(PyCallArgs& args);
+    bool ProcessArgs(PyCallArgs& args) override;
 };
 
 } // namespace CPyCppyy

--- a/src/CPPMethod.h
+++ b/src/CPPMethod.h
@@ -50,30 +50,30 @@ public:
     virtual ~CPPMethod();
 
 public:
-    virtual PyObject* GetSignature(bool show_formalargs = true);
-    virtual PyObject* GetPrototype(bool show_formalargs = true);
-    virtual PyObject* GetTypeName();
-    virtual PyObject* Reflex(Cppyy::Reflex::RequestId_t request,
-                             Cppyy::Reflex::FormatId_t = Cppyy::Reflex::OPTIMAL);
+    PyObject* GetSignature(bool show_formalargs = true) override;
+    PyObject* GetPrototype(bool show_formalargs = true) override;
+    PyObject* GetTypeName() override;
+    PyObject* Reflex(Cppyy::Reflex::RequestId_t request,
+                             Cppyy::Reflex::FormatId_t = Cppyy::Reflex::OPTIMAL) override;
 
-    virtual int       GetPriority();
-    virtual bool      IsGreedy();
+    int       GetPriority() override;
+    bool      IsGreedy() override;
 
-    virtual int       GetMaxArgs();
-    virtual PyObject* GetCoVarNames();
-    virtual PyObject* GetArgDefault(int iarg, bool silent=true);
-    virtual bool      IsConst();
+    int       GetMaxArgs() override;
+    PyObject* GetCoVarNames() override;
+    PyObject* GetArgDefault(int iarg, bool silent=true) override;
+    bool      IsConst() override;
 
-    virtual PyObject* GetScopeProxy();
-    virtual Cppyy::TCppFuncAddr_t GetFunctionAddress();
+    PyObject* GetScopeProxy() override;
+    Cppyy::TCppFuncAddr_t GetFunctionAddress() override;
 
-    virtual PyCallable* Clone() { return new CPPMethod(*this); }
+    PyCallable* Clone() override { return new CPPMethod(*this); }
 
-    virtual int       GetArgMatchScore(PyObject* args_tuple);
+    int       GetArgMatchScore(PyObject* args_tuple) override;
 
 public:
-    virtual PyObject* Call(CPPInstance*& self,
-        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr);
+    PyObject* Call(CPPInstance*& self,
+        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr) override;
 
 protected:
     virtual bool ProcessArgs(PyCallArgs& args);

--- a/src/CPPOperator.h
+++ b/src/CPPOperator.h
@@ -15,9 +15,9 @@ public:
     CPPOperator(Cppyy::TCppScope_t scope, Cppyy::TCppMethod_t method, const std::string& name);
 
 public:
-    virtual PyCallable* Clone() { return new CPPOperator(*this); }
-    virtual PyObject* Call(CPPInstance*& self,
-        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr);
+    PyCallable* Clone() override { return new CPPOperator(*this); }
+    PyObject* Call(CPPInstance*& self,
+        CPyCppyy_PyArgs_t args, size_t nargsf, PyObject* kwds, CallContext* ctxt = nullptr) override;
 
 private:
     binaryfunc fStub;

--- a/src/Converters.h
+++ b/src/Converters.h
@@ -46,10 +46,10 @@ public:
     VoidArrayConverter(bool keepControl = true) { fKeepControl = keepControl; }
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address, PyObject* ctxt = nullptr);
-    virtual bool HasState() { return true; }
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool ToMemory(PyObject* value, void* address, PyObject* ctxt = nullptr) override;
+    bool HasState() override { return true; }
 
 protected:
     virtual bool GetAddressSpecialCase(PyObject* pyobject, void*& address);
@@ -66,9 +66,9 @@ public:
         VoidArrayConverter(keepControl), fClass(klass) {}
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address, PyObject* ctxt = nullptr);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool ToMemory(PyObject* value, void* address, PyObject* ctxt = nullptr) override;
 
 protected:
     Cppyy::TCppType_t fClass;
@@ -79,7 +79,7 @@ public:
     using InstancePtrConverter<false>::InstancePtrConverter;
 
 protected:
-    virtual bool GetAddressSpecialCase(PyObject*, void*&) { return false; }
+    bool GetAddressSpecialCase(PyObject*, void*&) override { return false; }
 };
 
 } // namespace CPyCppyy

--- a/src/DeclareConverters.h
+++ b/src/DeclareConverters.h
@@ -17,36 +17,36 @@ namespace {
 #define CPPYY_DECLARE_BASIC_CONVERTER(name)                                  \
 class name##Converter : public Converter {                                   \
 public:                                                                      \
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);      \
-    virtual PyObject* FromMemory(void*);                                     \
-    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);            \
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;     \
+    PyObject* FromMemory(void*) override;                                    \
+    bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;           \
 };                                                                           \
                                                                              \
 class Const##name##RefConverter : public Converter {                         \
 public:                                                                      \
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);      \
-    virtual PyObject* FromMemory(void*);                                     \
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;     \
+    PyObject* FromMemory(void*) override;                                    \
 }
 
 
 #define CPPYY_DECLARE_BASIC_CONVERTER2(name, base)                           \
 class name##Converter : public base##Converter {                             \
 public:                                                                      \
-    virtual PyObject* FromMemory(void*);                                     \
-    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);            \
+    PyObject* FromMemory(void*) override;                                    \
+    bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;           \
 };                                                                           \
                                                                              \
 class Const##name##RefConverter : public Converter {                         \
 public:                                                                      \
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);      \
-    virtual PyObject* FromMemory(void*);                                     \
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;     \
+    PyObject* FromMemory(void*) override;                                    \
 }
 
 #define CPPYY_DECLARE_REFCONVERTER(name)                                     \
 class name##RefConverter : public Converter {                                \
 public:                                                                      \
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);      \
-    virtual PyObject* FromMemory(void*);                                     \
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;     \
+    PyObject* FromMemory(void*) override;                                    \
 };
 
 #define CPPYY_DECLARE_ARRAY_CONVERTER(name)                                  \
@@ -55,10 +55,10 @@ public:                                                                      \
     name##ArrayConverter(cdims_t dims);                                      \
     name##ArrayConverter(const name##ArrayConverter&) = delete;              \
     name##ArrayConverter& operator=(const name##ArrayConverter&) = delete;   \
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);      \
-    virtual PyObject* FromMemory(void*);                                     \
-    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);            \
-    virtual bool HasState() { return true; }                                 \
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;     \
+    PyObject* FromMemory(void*) override;                                    \
+    bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;           \
+    bool HasState() override { return true; }                                \
 protected:                                                                   \
     dims_t fShape;                                                           \
     bool fIsFixed;                                                           \
@@ -72,13 +72,13 @@ CPPYY_DECLARE_BASIC_CONVERTER(Char);
 class SCharAsIntConverter : public CharConverter {
 public:
     using CharConverter::CharConverter;
-    virtual PyObject* FromMemory(void*);
+    PyObject* FromMemory(void*) override;
 };
 CPPYY_DECLARE_BASIC_CONVERTER(UChar);
 class UCharAsIntConverter : public UCharConverter {
 public:
     using UCharConverter::UCharConverter;
-    virtual PyObject* FromMemory(void*);
+    PyObject* FromMemory(void*) override;
 };
 CPPYY_DECLARE_BASIC_CONVERTER(WChar);
 CPPYY_DECLARE_BASIC_CONVERTER(Char16);
@@ -119,7 +119,7 @@ CPPYY_DECLARE_REFCONVERTER(LDouble);
 
 class VoidConverter : public Converter {
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
 };
 
 class CStringConverter : public Converter {
@@ -127,10 +127,10 @@ public:
     CStringConverter(std::string::size_type maxSize = std::string::npos) : fMaxSize(maxSize) {}
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
-    virtual bool HasState() { return true; }
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
+    bool HasState() override { return true; }
 
 protected:
     std::string fBuffer;
@@ -142,8 +142,8 @@ public:
     using CStringConverter::CStringConverter;
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
 };
 
 class WCStringConverter : public Converter {
@@ -155,10 +155,10 @@ public:
     virtual ~WCStringConverter() { free(fBuffer); }
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
-    virtual bool HasState() { return true; }
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
+    bool HasState() override { return true; }
 
 protected:
     wchar_t* fBuffer;
@@ -174,10 +174,10 @@ public:
     virtual ~CString16Converter() { free(fBuffer); }
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
-    virtual bool HasState() { return true; }
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
+    bool HasState() override { return true; }
 
 protected:
     char16_t* fBuffer;
@@ -193,10 +193,10 @@ public:
     virtual ~CString32Converter() { free(fBuffer); }
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
-    virtual bool HasState() { return true; }
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
+    bool HasState() override { return true; }
 
 protected:
     char32_t* fBuffer;
@@ -232,8 +232,8 @@ public:
         fIsFixed = fixed;    // overrides SCharArrayConverter decision
     }
     using SCharArrayConverter::SCharArrayConverter;
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
 
 private:
     std::vector<const char*> fBuffer;
@@ -242,21 +242,21 @@ private:
 class NonConstCStringArrayConverter : public CStringArrayConverter {
 public:
     using CStringArrayConverter::CStringArrayConverter;
-    virtual PyObject* FromMemory(void* address);
+    PyObject* FromMemory(void* address) override;
 };
 
 // converters for special cases
 class NullptrConverter : public Converter {
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
 };
 
 class InstanceConverter : public StrictInstancePtrConverter {
 public:
     using StrictInstancePtrConverter::StrictInstancePtrConverter;
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void*);
-    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void*) override;
+    bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;
 };
 
 class InstanceRefConverter : public Converter  {
@@ -265,9 +265,9 @@ public:
         fClass(klass), fIsConst(isConst) {}
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool HasState() { return true; }
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool HasState() override { return true; }
 
 protected:
     Cppyy::TCppType_t fClass;
@@ -277,7 +277,7 @@ protected:
 class InstanceMoveConverter : public InstanceRefConverter  {
 public:
     InstanceMoveConverter(Cppyy::TCppType_t klass) : InstanceRefConverter(klass, true) {}
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
 };
 
 template <bool ISREFERENCE>
@@ -286,9 +286,9 @@ public:
     using InstancePtrConverter::InstancePtrConverter;
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
 };
 
 class InstanceArrayConverter : public InstancePtrConverter<false> {
@@ -299,9 +299,9 @@ public:
     InstanceArrayConverter& operator=(const InstanceArrayConverter&) = delete;
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
 
 protected:
     dims_t fShape;
@@ -313,10 +313,10 @@ public:
     ComplexDConverter(bool keepControl = false);
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
-    virtual bool HasState() { return true; }
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
+    bool HasState() override { return true; }
 
 private:
     std::complex<double> fBuffer;
@@ -327,14 +327,14 @@ private:
 // they come in a bazillion different guises, so just do whatever
 class STLIteratorConverter : public Converter {
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
 };
 // -- END CLING WORKAROUND
 
 
 class VoidPtrRefConverter : public Converter {
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
 };
 
 class VoidPtrPtrConverter : public Converter {
@@ -342,9 +342,9 @@ public:
     VoidPtrPtrConverter(cdims_t dims);
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool HasState() { return true; }
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool HasState() override { return true; }
 
 protected:
     dims_t fShape;
@@ -360,10 +360,10 @@ public:                                                                      \
     name##Converter(bool keepControl = true);                                \
                                                                              \
 public:                                                                      \
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);      \
-    virtual PyObject* FromMemory(void* address);                             \
-    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);            \
-    virtual bool HasState() { return true; }                                 \
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;     \
+    PyObject* FromMemory(void* address) override;                            \
+    bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;           \
+    bool HasState() override { return true; }                                \
                                                                              \
 protected:                                                                   \
     strtype fBuffer;                                                         \
@@ -380,7 +380,7 @@ public:
     using STLStringConverter::STLStringConverter;
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
 };
 
 
@@ -391,10 +391,10 @@ public:
         fRetType(ret), fSignature(sig) {}
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);
-    virtual bool HasState() { return true; }
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;
+    bool HasState() override { return true; }
 
 protected:
     std::string fRetType;
@@ -411,9 +411,9 @@ public:
     virtual ~StdFunctionConverter() { delete fConverter; }
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject* value, void* address, PyObject* = nullptr);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool ToMemory(PyObject* value, void* address, PyObject* = nullptr) override;
 
 protected:
     Converter* fConverter;
@@ -431,10 +431,10 @@ public:
           fKeepControl(keepControl), fIsRef(isRef) {}
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual PyObject* FromMemory(void* address);
-    virtual bool ToMemory(PyObject*, void*, PyObject* = nullptr);
-    virtual bool HasState() { return true; }
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    PyObject* FromMemory(void* address) override;
+    bool ToMemory(PyObject*, void*, PyObject* = nullptr) override;
+    bool HasState() override { return true; }
 
 protected:
     virtual bool GetAddressSpecialCase(PyObject*, void*&) { return false; }
@@ -455,8 +455,8 @@ public:
     virtual ~InitializerListConverter();
 
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
-    virtual bool HasState() { return true; }
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
+    bool HasState() override { return true; }
 
 protected:
     void Clear();
@@ -473,7 +473,7 @@ protected:
 // raising converter to take out overloads
 class NotImplementedConverter : public Converter {
 public:
-    virtual bool SetArg(PyObject*, Parameter&, CallContext* = nullptr);
+    bool SetArg(PyObject*, Parameter&, CallContext* = nullptr) override;
 };
 
 } // unnamed namespace

--- a/src/DeclareExecutors.h
+++ b/src/DeclareExecutors.h
@@ -19,8 +19,8 @@ namespace {
 #define CPPYY_DECL_EXEC(name)                                                \
 class name##Executor : public Executor {                                     \
 public:                                                                      \
-    virtual PyObject* Execute(                                               \
-        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*);             \
+    PyObject* Execute(                                                       \
+        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*) override;    \
 }
 
 // executors for built-ins
@@ -57,9 +57,9 @@ class name##ArrayExecutor : public Executor {                                \
     dims_t fShape;                                                           \
 public:                                                                      \
     name##ArrayExecutor(dims_t dims) : fShape(dims) {}                       \
-    virtual PyObject* Execute(                                               \
-        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*);             \
-    virtual bool HasState() { return true; }                                 \
+    PyObject* Execute(                                                       \
+        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*) override;    \
+    bool HasState() override { return true; }                                \
 }
 CPPYY_ARRAY_DECL_EXEC(Void);
 CPPYY_ARRAY_DECL_EXEC(Bool);
@@ -93,9 +93,9 @@ CPPYY_DECL_EXEC(STLWString);
 class InstancePtrExecutor : public Executor {
 public:
     InstancePtrExecutor(Cppyy::TCppType_t klass) : fClass(klass) {}
-    virtual PyObject* Execute(
-        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*);
-    virtual bool HasState() { return true; }
+    PyObject* Execute(
+        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*) override;
+    bool HasState() override { return true; }
 
 protected:
     Cppyy::TCppType_t fClass;
@@ -104,9 +104,9 @@ protected:
 class InstanceExecutor : public Executor {
 public:
     InstanceExecutor(Cppyy::TCppType_t klass);
-    virtual PyObject* Execute(
-        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*);
-    virtual bool HasState() { return true; }
+    PyObject* Execute(
+        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*) override;
+    bool HasState() override { return true; }
 
 protected:
     Cppyy::TCppType_t fClass;
@@ -124,8 +124,8 @@ CPPYY_DECL_EXEC(PyObject);
 #define CPPYY_DECL_REFEXEC(name)                                             \
 class name##RefExecutor : public RefExecutor {                               \
 public:                                                                      \
-    virtual PyObject* Execute(                                               \
-        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*);             \
+    PyObject* Execute(                                                       \
+        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*) override;    \
 }
 
 CPPYY_DECL_REFEXEC(Bool);
@@ -151,8 +151,8 @@ CPPYY_DECL_REFEXEC(STLString);
 class InstanceRefExecutor : public RefExecutor {
 public:
     InstanceRefExecutor(Cppyy::TCppType_t klass) : fClass(klass) {}
-    virtual PyObject* Execute(
-        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*);
+    PyObject* Execute(
+        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*) override;
 
 protected:
     Cppyy::TCppType_t fClass;
@@ -161,23 +161,23 @@ protected:
 class InstancePtrPtrExecutor : public InstanceRefExecutor {
 public:
     using InstanceRefExecutor::InstanceRefExecutor;
-    virtual PyObject* Execute(
-        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*);
+    PyObject* Execute(
+        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*) override;
 };
 
 class InstancePtrRefExecutor : public InstanceRefExecutor {
 public:
     using InstanceRefExecutor::InstanceRefExecutor;
-    virtual PyObject* Execute(
-        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*);
+    PyObject* Execute(
+        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*) override;
 };
 
 class InstanceArrayExecutor : public InstancePtrExecutor {
 public:
     InstanceArrayExecutor(Cppyy::TCppType_t klass, dim_t array_size)
         : InstancePtrExecutor(klass), fSize(array_size) {}
-    virtual PyObject* Execute(
-        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*);
+    PyObject* Execute(
+        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*) override;
 
 protected:
     dim_t fSize;
@@ -187,8 +187,8 @@ class FunctionPointerExecutor : public Executor {
 public:
     FunctionPointerExecutor(const std::string& ret, const std::string& sig) :
         fRetType(ret), fSignature(sig) {}
-    virtual PyObject* Execute(
-        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*);
+    PyObject* Execute(
+        Cppyy::TCppMethod_t, Cppyy::TCppObject_t, CallContext*) override;
 
 protected:
     std::string fRetType;

--- a/src/Executors.h
+++ b/src/Executors.h
@@ -25,7 +25,7 @@ class RefExecutor : public Executor {
 public:
     RefExecutor() : fAssignable(nullptr) {}
     virtual bool SetAssignable(PyObject*);
-    virtual bool HasState() { return true; }
+    bool HasState() override { return true; }
 
 protected:
     PyObject* fAssignable;

--- a/src/TemplateProxy.cxx
+++ b/src/TemplateProxy.cxx
@@ -101,7 +101,7 @@ PyObject* TemplateProxy::Instantiate(const std::string& fname,
                 memset(&bufinfo, 0, sizeof(Py_buffer));
                 std::string ptrdef;
                 if (PyObject_GetBuffer(itemi, &bufinfo, PyBUF_FORMAT) == 0) {
-                    for (int i = 0; i < bufinfo.ndim; ++i) ptrdef += "*";
+                    for (int j = 0; j < bufinfo.ndim; ++j) ptrdef += "*";
                     CPyCppyy_PyBuffer_Release(itemi, &bufinfo);
                 } else {
                     ptrdef += "*";


### PR DESCRIPTION
In ROOT we just had a campaign to use the `override` keyword where possible:
  * https://github.com/root-project/root/pull/18918

I guess it would be good to do the same thing here.