### PR TITLE
Enable using cppyy with debug build of Python

### DIFF
--- a/src/CPPScope.cxx
+++ b/src/CPPScope.cxx
@@ -258,6 +258,7 @@ static PyObject* pt_new(PyTypeObject* subtype, PyObject* args, PyObject* kwds)
                 // so make it accessible (the __cpp_cross__ data member also signals that
                 // this is a cross-inheritance class)
                     PyObject* bname = CPyCppyy_PyText_FromString(Cppyy::GetBaseName(result->fCppType, 0).c_str());
+                    PyErr_Clear();
                     if (PyObject_SetAttrString((PyObject*)result, "__cpp_cross__", bname) == -1)
                         PyErr_Clear();
                     Py_DECREF(bname);
@@ -542,6 +543,7 @@ static int meta_setattro(PyObject* pyclass, PyObject* pyname, PyObject* pyval)
         }
     }
 
+    PyErr_Clear(); // creation might have failed
     return PyType_Type.tp_setattro(pyclass, pyname, pyval);
 }
 

--- a/src/Pythonize.cxx
+++ b/src/Pythonize.cxx
@@ -1803,6 +1803,7 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
 
         // data with size
             Utility::AddToClass(pyclass, "__real_data", "data");
+            PyErr_Clear(); // AddToClass might have failed for data
             Utility::AddToClass(pyclass, "data", (PyCFunction)VectorData);
 
         // numpy array conversion

--- a/src/Utility.cxx
+++ b/src/Utility.cxx
@@ -552,9 +552,9 @@ static bool AddTypeName(std::string& tmpl_name, PyObject* tn, PyObject* arg,
             PyErr_Clear();
 
     // ctypes function pointer
-        PyObject* argtypes = PyObject_GetAttrString(arg, "argtypes");
-        PyObject* ret = PyObject_GetAttrString(arg, "restype");
-        if (argtypes && ret) {
+        PyObject* argtypes = nullptr;
+        PyObject* ret = nullptr;
+        if ((argtypes = PyObject_GetAttrString(arg, "argtypes")) && (ret = PyObject_GetAttrString(arg, "restype"))) {
             std::ostringstream tpn;
             PyObject* pytc = PyObject_GetAttr(ret, PyStrings::gCTypesType);
             tpn << CT2CppNameS(pytc, false)
@@ -895,6 +895,7 @@ Py_ssize_t CPyCppyy::Utility::GetBuffer(PyObject* pyobject, char tc, int size, v
     if (PyObject_CheckBuffer(pyobject)) {
         if (PySequence_Check(pyobject) && !PySequence_Size(pyobject))
             return 0;   // PyObject_GetBuffer() crashes on some platforms for some zero-sized seqeunces
+        PyErr_Clear();
 
         Py_buffer bufinfo;
         memset(&bufinfo, 0, sizeof(Py_buffer));


### PR DESCRIPTION
The changes here collects residual exceptions thrown by Python, before calling into Python C API.

Reference: https://github.com/root-project/root/pull/19239