### PR TITLE
Provide private API to set CPPInstance `__reduce__` callback

### DIFF
--- a/src/CPPInstance.cxx
+++ b/src/CPPInstance.cxx
@@ -400,6 +400,21 @@ static PySequenceMethods op_as_sequence = {
     0,                             // sq_inplace_repeat
 };
 
+std::function<PyObject *(PyObject *)> &CPPInstance::ReduceMethod() {
+   static std::function<PyObject *(PyObject *)> reducer;
+   return reducer;
+}
+
+PyObject *op_reduce(PyObject *self, PyObject * /*args*/)
+{
+   auto &reducer = CPPInstance::ReduceMethod();
+   if (!reducer) {
+      PyErr_SetString(PyExc_NotImplementedError, "");
+      return nullptr;
+   }
+   return reducer(self);
+}
+
 
 //----------------------------------------------------------------------------
 static PyMethodDef op_methods[] = {
@@ -409,6 +424,8 @@ static PyMethodDef op_methods[] = {
       (char*)"dispatch to selected overload"},
     {(char*)"__smartptr__", (PyCFunction)op_get_smartptr, METH_NOARGS,
       (char*)"get associated smart pointer, if any"},
+    {(char*)"__reduce__",  (PyCFunction)op_reduce, METH_NOARGS,
+        (char*)"reduce method for serialization"},
     {(char*)"__reshape__",  (PyCFunction)op_reshape, METH_O,
         (char*)"cast pointer to 1D array type"},
     {(char*)nullptr, nullptr, 0, nullptr}

--- a/src/CPPInstance.h
+++ b/src/CPPInstance.h
@@ -15,6 +15,7 @@
 #include "CallContext.h"     // for Parameter
 
 // Standard
+#include <functional>
 #include <utility>
 #include <vector>
 
@@ -82,6 +83,11 @@ public:
 // redefine pointer to object as fixed-size array
     void CastToArray(Py_ssize_t sz);
     Py_ssize_t ArrayLength();
+
+// implementation of the __reduce__ method: doesn't wrap any function by
+// default but can be re-assigned by libraries that add C++ object
+// serialization support, like ROOT
+    static std::function<PyObject *(PyObject *)> &ReduceMethod();
 
 private:
     void  CreateExtension();


### PR DESCRIPTION
**Upstream version of https://github.com/root-project/root/pull/19222**


The CPPIntance type is immutable, and new attributes can't be set:
```txt
import cppyy
>>> setattr(cppyy._backend.CPPInstance, "test", 10)
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    setattr(cppyy._backend.CPPInstance, "test", 10)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cannot set 'test' attribute of immutable type 'cppyy.CPPInstance'
>>>
```

In our pythonizations, we still want to monkey-patch a `__reduce__` method anyway, and to make Python not complain we to a hack by setting the attribute with the C Python API using `PyObject_GenericSetAttr`. This function doesn't normally do any safety checks, and our monkey patching works.

However, the Python debug build is not having any of that, thanks to a new assert that was added a year ago:

https://github.com/python/cpython/blame/c419af9e277bea7dd78f4defefc752fe93b0b8ec/Objects/object.c#L1921

To make the ROOT Python interface work with debug builds of the Python interpreter, we therefore have to implement adding the reduce method properly.

This commit suggests to achieve this by defining the `__reduce__` method in the immutable CPPInstance type within CPyCppyy, but in such a way that its implementation can be routed to ROOT via a private API.