### PR TITLE
Avoid using deprecated `_Py_HashPointer` function

### DIFF
--- a/src/CPPOverload.cxx
+++ b/src/CPPOverload.cxx
@@ -887,7 +887,11 @@ static Py_ssize_t mp_hash(CPPOverload* pymeth)
 {
 // Hash of method proxy object for insertion into dictionaries; with actual
 // method (fMethodInfo) shared, its address is best suited.
+#if PY_VERSION_HEX >= 0x030d0000
+    return Py_HashPointer(pymeth->fMethodInfo);
+#else
     return _Py_HashPointer(pymeth->fMethodInfo);
+#endif
 }
 
 //----------------------------------------------------------------------------

--- a/src/CPyCppyyModule.cxx
+++ b/src/CPyCppyyModule.cxx
@@ -146,7 +146,11 @@ static PyTypeObject PyNullPtr_t_Type = {
     nullptr_repr,        // tp_repr
     &nullptr_as_number,  // tp_as_number
     0, 0,
+#if PY_VERSION_HEX >= 0x030d0000
+    (hashfunc)Py_HashPointer, // tp_hash
+#else
     (hashfunc)_Py_HashPointer, // tp_hash
+#endif
     0, 0, 0, 0, 0, Py_TPFLAGS_DEFAULT, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 #if PY_VERSION_HEX >= 0x02030000
@@ -189,7 +193,11 @@ static PyTypeObject PyDefault_t_Type = {
     0, 0, 0, 0,
     default_repr,        // tp_repr
     0, 0, 0,
+#if PY_VERSION_HEX >= 0x030d0000
+    (hashfunc)Py_HashPointer, // tp_hash
+#else
     (hashfunc)_Py_HashPointer, // tp_hash
+#endif
     0, 0, 0, 0, 0, Py_TPFLAGS_DEFAULT, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 #if PY_VERSION_HEX >= 0x02030000


### PR DESCRIPTION
The `_Py_HashPointer` function was deprecated in Python 3.13 because it was promoted to be part of the stable API. Using the stable API version for Python >= 3.13 avoids build warnings.