### PR TITLE
Avoid false positives in `size()` pythonization

### DIFF
--- a/src/Pythonize.cxx
+++ b/src/Pythonize.cxx
@@ -1624,8 +1624,12 @@ bool CPyCppyy::Pythonize(PyObject* pyclass, const std::string& name)
     }
 
 // for STL containers, and user classes modeled after them
-    if (HasAttrDirect(pyclass, PyStrings::gSize))
+// the attribute must be a CPyCppyy overload, otherwise the check gives false
+// positives in the case where the class has a non-function attribute that is
+// called "size".
+    if (HasAttrDirect(pyclass, PyStrings::gSize, /*mustBeCPyCppyy=*/ true)) {
         Utility::AddToClass(pyclass, "__len__", "size");
+    }
 
     if (!IsTemplatedSTLClass(name, "vector")  &&      // vector is dealt with below
            !((PyTypeObject*)pyclass)->tp_iter) {


### PR DESCRIPTION
When checking if a class has the `size()` method implemented in the style of the STL, the attribute must be a CPyCppyy overload. Otherwise the check gives false positives in the case where the class has a non-function attribute that is called "size".

This problem was caught in the Python debug interpreter.

Upstream version of https://github.com/root-project/root/pull/19240.