### PR TITLE
Fix invalid overload selections via explicit constructors

### DIFF
--- a/src/CPPConstructor.cxx
+++ b/src/CPPConstructor.cxx
@@ -77,6 +77,15 @@ PyObject* CPyCppyy::CPPConstructor::Call(CPPInstance*& self,
         return nullptr;
     }
 
+    const auto cppScopeFlags = ((CPPScope*)Py_TYPE(self))->fFlags;
+
+// Do nothing if the constructor is explicit and we are in an implicit
+// conversion context. We recognize this by checking the CPPScope::kNoImplicit
+// flag, as further implicit conversions are disabled to prevent infinite
+// recursion. See also the ConvertImplicit() helper in Converters.cxx.
+    if((cppScopeFlags & CPPScope::kNoImplicit) && Cppyy::IsExplicit(GetMethod()))
+        return nullptr;
+
 // self provides the python context for lifelines
     if (!ctxt->fPyContext)
         ctxt->fPyContext = (PyObject*)cargs.fSelf;    // no Py_INCREF as no ownership
@@ -125,7 +134,7 @@ PyObject* CPyCppyy::CPPConstructor::Call(CPPInstance*& self,
 
     } else {
     // translate the arguments
-        if (((CPPClass*)Py_TYPE(self))->fFlags & CPPScope::kNoImplicit)
+        if (cppScopeFlags & CPPScope::kNoImplicit)
             ctxt->fFlags |= CallContext::kNoImplicit;
         if (!this->ConvertAndSetArgs(cargs.fArgs, cargs.fNArgsf, ctxt))
             return nullptr;

--- a/src/Cppyy.h
+++ b/src/Cppyy.h
@@ -251,6 +251,8 @@ namespace Cppyy {
     bool IsDestructor(TCppMethod_t method);
     CPPYY_IMPORT
     bool IsStaticMethod(TCppMethod_t method);
+    CPPYY_IMPORT
+    bool IsExplicit(TCppMethod_t method);
 
 // data member reflection information ----------------------------------------
     CPPYY_IMPORT


### PR DESCRIPTION
In C++, it is forbidden to use `explicit` constructors in implicit conversions, but cppyy was not aware of this so far.

This commit fixes that by disabling explicit constructors in the context of implicit conversions.

Taken from https://github.com/root-project/root/pull/19513