### PR TITLE
Split up `CPyCppyyModule.cxx` up into two files

### DIFF
--- a/src/CPyCppyyModule.cxx
+++ b/src/CPyCppyyModule.cxx
@@ -1074,21 +1074,18 @@ static struct PyModuleDef moduledef = {
     cpycppyymodule_clear,
     nullptr
 };
+#endif
 
+namespace CPyCppyy {
 
 //----------------------------------------------------------------------------
-#define CPYCPPYY_INIT_ERROR return nullptr
-extern "C" PyObject* PyInit_libcppyy()
-#else
-#define CPYCPPYY_INIT_ERROR return
-extern "C" void initlibcppyy()
-#endif
+PyObject* Init()
 {
 // Initialization of extension module libcppyy.
 
 // load commonly used python strings
     if (!CPyCppyy::CreatePyStrings())
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
 // setup interpreter
 #if PY_VERSION_HEX < 0x03090000
@@ -1117,7 +1114,7 @@ extern "C" void initlibcppyy()
     gThisModule = Py_InitModule(const_cast<char*>("libcppyy"), gCPyCppyyMethods);
 #endif
     if (!gThisModule)
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
 // keep gThisModule, but do not increase its reference count even as it is borrowed,
 // or a self-referencing cycle would be created
@@ -1131,58 +1128,58 @@ extern "C" void initlibcppyy()
 
 // inject meta type
     if (!Utility::InitProxy(gThisModule, &CPPScope_Type, "CPPScope"))
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
 // inject object proxy type
     if (!Utility::InitProxy(gThisModule, &CPPInstance_Type, "CPPInstance"))
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
 // inject exception object proxy type
     if (!Utility::InitProxy(gThisModule, &CPPExcInstance_Type, "CPPExcInstance"))
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
 // inject method proxy type
     if (!Utility::InitProxy(gThisModule, &CPPOverload_Type, "CPPOverload"))
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
 // inject template proxy type
     if (!Utility::InitProxy(gThisModule, &TemplateProxy_Type, "TemplateProxy"))
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
 // inject property proxy type
     if (!Utility::InitProxy(gThisModule, &CPPDataMember_Type, "CPPDataMember"))
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
 // inject custom data types
 #if PY_VERSION_HEX < 0x03000000
     if (!Utility::InitProxy(gThisModule, &RefFloat_Type, "Double"))
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
     if (!Utility::InitProxy(gThisModule, &RefInt_Type, "Long"))
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 #endif
 
     if (!Utility::InitProxy(gThisModule, &CustomInstanceMethod_Type, "InstanceMethod"))
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
     if (!Utility::InitProxy(gThisModule, &TupleOfInstances_Type, "InstanceArray"))
-       CPYCPPYY_INIT_ERROR;
+       return nullptr;;
 
     if (!Utility::InitProxy(gThisModule, &LowLevelView_Type, "LowLevelView"))
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
     if (!Utility::InitProxy(gThisModule, &PyNullPtr_t_Type, "nullptr_t"))
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
 // custom iterators
     if (PyType_Ready(&InstanceArrayIter_Type) < 0)
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
     if (PyType_Ready(&IndexIter_Type) < 0)
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
     if (PyType_Ready(&VectorIter_Type) < 0)
-        CPYCPPYY_INIT_ERROR;
+        return nullptr;;
 
 // inject identifiable nullptr and default
     gNullPtrObject = (PyObject*)&_CPyCppyy_NullPtrStruct;
@@ -1219,6 +1216,8 @@ extern "C" void initlibcppyy()
 
 #if PY_VERSION_HEX >= 0x03000000
     Py_INCREF(gThisModule);
-    return gThisModule;
 #endif
+    return gThisModule;
 }
+
+} // namespace CPyCppyy

--- a/src/CPyCppyyModule.h
+++ b/src/CPyCppyyModule.h
@@ -1,0 +1,12 @@
+#ifndef CPYCPPYY_CPYCPPYYMODULE_H
+#define CPYCPPYY_CPYCPPYYMODULE_H
+
+#include "Python.h"
+
+namespace CPyCppyy {
+
+PyObject *Init();
+
+}
+
+#endif // !CPYCPPYY_CPYCPPYYMODULE_H

--- a/src/CPyCppyyPyModule.cxx
+++ b/src/CPyCppyyPyModule.cxx
@@ -1,0 +1,13 @@
+#include "CPyCppyyModule.h"
+
+//----------------------------------------------------------------------------
+#if PY_VERSION_HEX >= 0x03000000
+extern "C" PyObject* PyInit_libcppyy() {
+#else
+extern "C" void initlibcppyy() {
+#endif
+    PyObject *thisModule = CPyCppyy::Init();
+#if PY_VERSION_HEX >= 0x03000000
+    return thisModule;
+#endif
+}


### PR DESCRIPTION
In ROOT, we're actually using CPyCppyy in two ways:

  1. As a library, that ROOT's TPython library is linked against

  2. As the CPython extension that is imported from Python

The problem with this is if the Python site packages directory is not the same as the ROOT library directory, we needed to install the library in two places so both Python and TPython can find it. This was solved with system links.

The problem with system links is that they are not allowed in the ROOT Python wheels.

To fix this problem, we split up CPyCppyy into a "normal" library, and a CPython extension that is linked against this library. Then, we put the relative path to the library part into the `rpath` of the CPython extension, and all works fine.

This requires however to have some source file for the CPython extension part, which was solved in a minimal fashion by having just one function that initializes the module by calling the library. In other words: the `CPyCppyyModule.cxx` was split into a library part, and another translation unit that contains the `extern "C" PyObject* PyInit_libcppyy()`.

It would be great if this can be done in upstream CPyCppyy as well, to keep the code in sync. For upstream CPyCppyy, this should be non-controversial, because the `CMakeLists.txt` is not changed. So the resulting shared library is still the same, the split into different translation units is just different.