### PR TITLE
Don't add item converters to InitializerListConverter forever

### DIFF
--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -3073,8 +3073,9 @@ bool CPyCppyy::InitializerListConverter::SetArg(
             PyObject* item = PySequence_GetItem(pyobject, i);
             bool convert_ok = false;
             if (item) {
-                Converter *converter = CreateConverter(fValueTypeName);
-                if (!converter) {
+                if (fConverters.empty())
+                    fConverters.emplace_back(CreateConverter(fValueTypeName));
+                if (!fConverters.back()) {
                     if (CPPInstance_Check(item)) {
                     // by convention, use byte copy
                         memcpy((char*)fake->_M_array + i*fValueSize,
@@ -3095,9 +3096,11 @@ bool CPyCppyy::InitializerListConverter::SetArg(
                         }
                     }
                     if (memloc) {
-                        convert_ok = converter->ToMemory(item, memloc);
+                        if (i >= fConverters.size()) {
+                            fConverters.emplace_back(CreateConverter(fValueTypeName));
+                        }
+                        convert_ok = fConverters[i]->ToMemory(item, memloc);
                     }
-                    fConverters.emplace_back(converter);
                 }
 
 


### PR DESCRIPTION
Follows up on 8b7145f45, fixing a memory leak that I introduced in this commit.

Corresponding ROOT PR:

  * https://github.com/root-project/root/pull/19745