### PR TITLE
Correctly handle static method calls via derived instance

### DIFF
--- a/src/CPPClassMethod.cxx
+++ b/src/CPPClassMethod.cxx
@@ -34,8 +34,8 @@ PyObject* CPyCppyy::CPPClassMethod::Call(CPPInstance*&
     int nargs = (int)CPyCppyy_PyArgs_GET_SIZE(args, nargsf);
     if ((!self || (PyObject*)self == Py_None) && nargs) {
         PyObject* arg0 = CPyCppyy_PyArgs_GET_ITEM(args, 0);
-        if ((CPPInstance_Check(arg0) && ((CPPInstance*)arg0)->ObjectIsA() == GetScope()) && \
-                (fArgsRequired <= nargs-1)) {
+        if (CPPInstance_Check(arg0) && fArgsRequired <= nargs - 1 &&
+            Cppyy::IsSubtype(reinterpret_cast<CPPInstance *>(arg0)->ObjectIsA(), GetScope())) {
             args   += 1;     // drops first argument
             nargsf -= 1;
         }


### PR DESCRIPTION
The mechanism to strip away the "self" argument from the call to a static method checks the type of "self", matching the exact type.

However, it should also remove the "self" if it is an instance of a derived type, because in C++ it is also possible to call static methods via instances of derived types.

Corresponding ROOT commit:
https://github.com/root-project/root/commit/f30e8fd5c32bceee543586998fd5273210003394

The original user report and ROOT PR:
  * https://github.com/root-project/root/issues/20463
  * https://github.com/root-project/root/pull/20496

Corresponding `cppyy` PR to add a test:
  * https://github.com/wlav/cppyy/pull/328