### PR TITLE
Disallow conversion from C++ instance to function pointers

### DIFF
--- a/src/Converters.cxx
+++ b/src/Converters.cxx
@@ -2606,7 +2606,7 @@ static PyMethodDef gWrapperCacheEraserMethodDef = {
 };
 
 static void* PyFunction_AsCPointer(PyObject* pyobject,
-    const std::string& rettype, const std::string& signature)
+    const std::string& rettype, const std::string& signature, bool allowCppInstance)
 {
 // Convert a bound C++ function pointer or callable python object to a C-style
 // function pointer. The former is direct, the latter involves a JIT-ed wrapper.
@@ -2653,8 +2653,11 @@ static void* PyFunction_AsCPointer(PyObject* pyobject,
         return fptr;
     }
 
-    if (PyCallable_Check(pyobject)) {
+    if (PyCallable_Check(pyobject) && (allowCppInstance || !CPPInstance_Check(pyobject))) {
     // generic python callable: create a C++ wrapper function
+    // Sometimes we don't want to take this branch if the object is a C++
+    // instance, because C++ doesn't allow converting functor objects to
+    // function pointers, but only to std::function.
         void* wpraddress = nullptr;
 
     // re-use existing wrapper if possible
@@ -2759,7 +2762,7 @@ bool CPyCppyy::FunctionPointerConverter::SetArg(
     }
 
 // normal case, get a function pointer
-    void* fptr = PyFunction_AsCPointer(pyobject, fRetType, fSignature);
+    void* fptr = PyFunction_AsCPointer(pyobject, fRetType, fSignature, fAllowCppInstance);
     if (fptr) {
         SetLifeLine(ctxt->fPyContext, pyobject, (intptr_t)this);
         para.fValue.fVoidp = fptr;
@@ -2791,7 +2794,7 @@ bool CPyCppyy::FunctionPointerConverter::ToMemory(
     }
 
 // normal case, get a function pointer
-    void* fptr = PyFunction_AsCPointer(pyobject, fRetType, fSignature);
+    void* fptr = PyFunction_AsCPointer(pyobject, fRetType, fSignature, fAllowCppInstance);
     if (fptr) {
         SetLifeLine(ctxt, pyobject, (intptr_t)address);
         *((void**)address) = fptr;

--- a/src/DeclareConverters.h
+++ b/src/DeclareConverters.h
@@ -399,13 +399,16 @@ public:
 protected:
     std::string fRetType;
     std::string fSignature;
+    bool fAllowCppInstance = false;
 };
 
 // std::function
 class StdFunctionConverter : public FunctionPointerConverter {
 public:
     StdFunctionConverter(Converter* cnv, const std::string& ret, const std::string& sig) :
-        FunctionPointerConverter(ret, sig), fConverter(cnv) {}
+        FunctionPointerConverter(ret, sig), fConverter(cnv) {
+        fAllowCppInstance = true;
+    }
     StdFunctionConverter(const StdFunctionConverter&) = delete;
     StdFunctionConverter& operator=(const StdFunctionConverter&) = delete;
     virtual ~StdFunctionConverter() { delete fConverter; }


### PR DESCRIPTION
Implicit conversion from C++ instances to function pointers is not allowed in C++, and it can result in confusing overload resolutions if we allow it in cppyy.

See:
  * https://github.com/root-project/root/issues/20687#issuecomment-3641579159

Corresponding ROOT commit:
  * https://github.com/root-project/root/commit/9976d3bcebd493dfcaef539c56a47c503767da13#diff-5c6046149708192850b028f56795eafff3a409f2eba6e02790beb0c14423844f

Corresponding `cppyy` PR with the unit test:
  * https://github.com/wlav/cppyy/pull/329